### PR TITLE
Propagate PATH from external environment to scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,6 +1,6 @@
 import os
 
-env = Environment()
+env = Environment(ENV = {'PATH' : os.environ['PATH']})
 
 '''
 	Compiler flags

--- a/examples/basic/SConscript
+++ b/examples/basic/SConscript
@@ -1,6 +1,8 @@
+import os
+
 Import('env')
 
-clinode_env = Environment()
+clinode_env = Environment(ENV = {'PATH' : os.environ['PATH']})
 clinode_env.Append(CCFLAGS = env['CCFLAGS'])
 clinode_env.Append(CXXFLAGS = env['CXXFLAGS'])
 clinode_env.Append(LIBPATH = env['LIBPATH'])

--- a/examples/bench_node/SConscript
+++ b/examples/bench_node/SConscript
@@ -1,6 +1,8 @@
+import os
+
 Import('env')
 
-bench_env = Environment()
+bench_env = Environment(ENV = {'PATH' : os.environ['PATH']})
 bench_env.Append(CCFLAGS = env['CCFLAGS'])
 bench_env.Append(CXXFLAGS = env['CXXFLAGS'])
 bench_env.Append(LIBPATH = env['LIBPATH'])

--- a/examples/cli_node/SConscript
+++ b/examples/cli_node/SConscript
@@ -1,6 +1,7 @@
+import os
 Import('env')
 
-clinode_env = Environment()
+clinode_env = Environment(ENV = {'PATH' : os.environ['PATH']})
 clinode_env.Append(CCFLAGS = env['CCFLAGS'])
 clinode_env.Append(CXXFLAGS = env['CXXFLAGS'])
 clinode_env.Append(LIBPATH = env['LIBPATH'])

--- a/examples/fabric_node/SConscript
+++ b/examples/fabric_node/SConscript
@@ -1,6 +1,8 @@
+import os
+
 Import('env')
 
-fabric_env = Environment()
+fabric_env = Environment(ENV = {'PATH' : os.environ['PATH']})
 fabric_env.Append(CCFLAGS = env['CCFLAGS'])
 fabric_env.Append(CXXFLAGS = env['CXXFLAGS'])
 fabric_env.Append(LIBPATH = env['LIBPATH'])


### PR DESCRIPTION
This is useful when using devtoolset, or one would
like to use different compiler.