### PR TITLE
Fix error handling.

### DIFF
--- a/examples/cli_node/node.cpp
+++ b/examples/cli_node/node.cpp
@@ -140,7 +140,7 @@ main(int argc, const char *argv[])
 	try {
 		spKVStore = shared_ptr<FogKV::KVStoreBase>(FogKV::KVStoreBase::Open(options));
 	} catch (FogKV::OperationFailedException e) {
-		cerr << "Failed to create KVStore: " << e.status().to_string() << endl;
+		cerr << "Failed to create KVStore: " << e.what() << endl;
 		return -1;
 	}
 

--- a/include/FogKV/Status.h
+++ b/include/FogKV/Status.h
@@ -31,11 +31,16 @@
  */
 #pragma once
 
+#include <string>
+#include <cstring>
+#include <limits>
+
 namespace FogKV {
 
-enum Code {
-	Ok,
-	InvalidArgument,
+enum Code : long {
+	Ok = 0,
+
+	_max_errno = std::numeric_limits<int>::max(),
 	KeyNotFound,
 
 	NotImplemented,
@@ -47,6 +52,9 @@ struct Status {
 	Status() : _code(Ok)
 	{ }
 
+	Status(int errnum) : _code(static_cast<Code>(errnum))
+	{ }
+
 	Status(Code c) : _code(c)
 	{ }
 	
@@ -56,11 +64,10 @@ struct Status {
 
 	std::string to_string()
 	{
+		if (_code < _max_errno)
+			return ::strerror((int)_code);
+
 		switch (_code) {
-		case Ok:
-			return "Ok";
-		case InvalidArgument:
-			return "Invalid Argument";
 		case NotImplemented:
 			return "Not Implemented";
 		default:
@@ -70,5 +77,7 @@ struct Status {
 
 	Code _code;
 };
+
+Status errno2status(int err);
 
 } // namespace FogKV

--- a/include/FogKV/Types.h
+++ b/include/FogKV/Types.h
@@ -46,14 +46,34 @@ public:
 	NotImplementedException(): logic_error("Not Implemented") {}
 };
 
-class OperationFailedException : public std::exception {
+class OperationFailedException : public std::runtime_error {
 public:
-	OperationFailedException(Status s) :
-		_status(s) { }
-	OperationFailedException() :
-		_status(UnknownError) { }
+	OperationFailedException(Status s, const std::string &msg = "") :
+		runtime_error(msg),
+		_status(s) { set_what(); }
+	OperationFailedException(const std::string &msg = "") :
+		runtime_error(msg),
+		_status(UnknownError) { set_what(); }
+	OperationFailedException(int errnum, std::string msg = "") :
+		runtime_error(msg),
+		_status(errnum) { set_what(); }
+
+	virtual const char *what() const noexcept {
+		return _what.c_str();
+	}
+
 	Status status() { return _status; }
 	Status _status;
+	std::string _what;
+private:
+	void set_what() {
+		_what = runtime_error::what();
+
+		if (!_status.ok() &&
+			_what.find(_status.to_string()) == std::string::npos) {
+			_what += ": " + _status.to_string();
+		}
+	}
 };
 
 } // namespace FogKV

--- a/lib/store/KVStoreBaseImpl.h
+++ b/lib/store/KVStoreBaseImpl.h
@@ -71,7 +71,7 @@ protected:
 	KVStoreBaseImpl(const Options &options);
 	virtual ~KVStoreBaseImpl();
 
-	Status init();
+	void init();
 	void registerProperties();
 
 	asio::io_service &io_service();


### PR DESCRIPTION
If there was a problem with creating pmemkv instance in KVStoreBaseImpl
constructor an exception has been thrown. After that the destructor of
cChordAdapter has been invoked which calls exit(0). In result there was no
error message printed in cli_node example.