### PR TITLE
Fix FogKV::Options initialization.

### DIFF
--- a/include/FogKV/Options.h
+++ b/include/FogKV/Options.h
@@ -117,17 +117,17 @@ struct RuntimeOptions {
 		return _io_service;
 	}
 
-	asio::io_service *_io_service;
+	asio::io_service *_io_service = nullptr;
 };
 
 struct DhtOptions {
-	unsigned short Port;
-	NodeId Id;
+	unsigned short Port = 0;
+	NodeId Id = 0;
 };
 
 struct PMEMOptions {
 	std::string Path;
-	size_t Size;
+	size_t Size = 0;
 };
 
 struct Options {
@@ -140,7 +140,7 @@ public:
 	DhtOptions Dht;
 
 	// TODO move to struct ?
-	unsigned short Port;
+	unsigned short Port = 0;
 
 	std::string KVEngine = "kvtree";
 	PMEMOptions PMEM;


### PR DESCRIPTION
This patch add default values in FogKV::Options.
Without this change in KVStoreBaseImpl::Open we have
no clue if for example io_service is set.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>