### PR TITLE
libdpdk.a building fails on latest spdk

### DIFF
--- a/scripts/libspdk.mri
+++ b/scripts/libspdk.mri
@@ -55,16 +55,11 @@ addlib dpdk/build/lib/librte_bus_pci.a
 addlib dpdk/build/lib/librte_bus_vdev.a
 addlib dpdk/build/lib/librte_eal.a
 addlib dpdk/build/lib/librte_ethdev.a
-addlib dpdk/build/lib/librte_gso.a
-addlib dpdk/build/lib/librte_kvargs.a
 addlib dpdk/build/lib/librte_mbuf.a
 addlib dpdk/build/lib/librte_mempool.a
-addlib dpdk/build/lib/librte_mempool_octeontx.a
 addlib dpdk/build/lib/librte_mempool_ring.a
-addlib dpdk/build/lib/librte_metrics.a
 addlib dpdk/build/lib/librte_net.a
 addlib dpdk/build/lib/librte_pci.a
 addlib dpdk/build/lib/librte_ring.a
-addlib dpdk/build/lib/librte_timer.a
 save
 end


### PR DESCRIPTION
This patch fixes creating of libdpdk.a, latest spdk/dpdk has remove
some of libraries listed in scripts/libspdk.mri

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>