### PR TITLE
Reserve publish init

### DIFF
--- a/lib/store/RTree.cpp
+++ b/lib/store/RTree.cpp
@@ -135,9 +135,9 @@ void Tree::allocateLevel(persistent_ptr<Node> current, int depth, int *count) {
 
         make_persistent_atomic<Node>(_pm_pool, current->children[i], isLast,
                                      depth);
-        if(isLast) {
-        	make_persistent_atomic<ValueWrapper[]>(
-            _pm_pool, current->children[i]->valueNode, LEVEL_SIZE);
+        if (isLast) {
+            make_persistent_atomic<ValueWrapper[]>(
+                _pm_pool, current->children[i]->valueNode, LEVEL_SIZE);
         }
         if (depth < (treeRoot->tree_heigh - 1)) {
             allocateLevel(current->children[i], depth, count);

--- a/lib/store/RTree.h
+++ b/lib/store/RTree.h
@@ -55,7 +55,7 @@ using namespace pmem::obj;
 // Number of keys slots inside Node (not key bits)
 #define LEVEL_SIZE 4
 // Number of key bits
-#define KEY_SIZE 20			/** @TODO jschmieg: target value is 24 bits */
+#define KEY_SIZE 20 /** @TODO jschmieg: target value is 24 bits */
 
 namespace FogKV {
 


### PR DESCRIPTION
Initial version of Reserve-publish API from PMDK instead of transactional allocations. PUT actions are volatile now. Address of RAM allocated array of actions is stored in RTree in order to publish/cancel it in other functions.