### PR TITLE
Additional unit tests for RqstPooler

### DIFF
--- a/lib/store/RqstPooler.h
+++ b/lib/store/RqstPooler.h
@@ -87,12 +87,12 @@ class RqstPooler : public RqstPoolerInterface {
     std::shared_ptr<FogKV::RTreeEngine> rtree;
     struct spdk_ring *rqstRing;
 
+    unsigned short processArrayCount = 0;
+    RqstMsg *processArray[DEQUEUE_RING_LIMIT];
+
   private:
     void _ThreadMain(void);
-
     std::thread *_thread;
-    unsigned short _rqstDequedCount = 0;
-    RqstMsg *_rqstMsgBuffer[DEQUEUE_RING_LIMIT];
 };
 
 } /* namespace FogKV */


### PR DESCRIPTION
This patch provides tests for GET/PUT use cases for RqstPooler class.
This patch move several RqstPooler fields to enable unit test writing.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>