### PR TITLE
Removing strings from Alloc function chain

### DIFF
--- a/lib/store/KVStoreBaseImpl.cpp
+++ b/lib/store/KVStoreBaseImpl.cpp
@@ -201,9 +201,8 @@ void KVStoreBaseImpl::RemoveRange(const Key &beg, const Key &end) {
 
 Value KVStoreBaseImpl::Alloc(const Key &key, size_t size,
                              const AllocOptions &options) {
-    std::string keyStr(key.data(), mKeySize);
     char *val;
-    mRTree->AllocValueForKey(keyStr, size, &val);
+    mRTree->AllocValueForKey((int)(*key.data()), size, &val);
     return Value(val, size);
 }
 

--- a/lib/store/RTree.cpp
+++ b/lib/store/RTree.cpp
@@ -105,10 +105,9 @@ StatusCode RTree::Put(const char *key, int32_t keybytes, const char *value,
 
 StatusCode RTree::Remove(const string &key) { return StatusCode::Ok; }
 
-StatusCode RTree::AllocValueForKey(const string &key, size_t size,
-                                   char **value) {
+StatusCode RTree::AllocValueForKey(int key, size_t size, char **value) {
     ValueWrapper *val =
-        tree->findValueInNode(tree->treeRoot->rootNode, atoi(key.c_str()));
+        tree->findValueInNode(tree->treeRoot->rootNode, key);
     try {
         val->actionValue = new pobj_action[1];
         pmemoid poid;

--- a/lib/store/RTree.h
+++ b/lib/store/RTree.h
@@ -107,8 +107,7 @@ class RTree : public FogKV::RTreeEngine {
     StatusCode Put(const char *key, int32_t keybytes, const char *value,
                    int32_t valuebytes) final;
     StatusCode Remove(const string &key) final; // remove value for key
-    StatusCode AllocValueForKey(const string &key, size_t size,
-                                char **value) final;
+    StatusCode AllocValueForKey(int key, size_t size, char **value) final;
 
   private:
     Tree *tree;

--- a/lib/store/RTreeEngine.h
+++ b/lib/store/RTreeEngine.h
@@ -62,7 +62,7 @@ class RTreeEngine {
     virtual StatusCode Put(const char *key, int32_t keybytes, const char *value,
                            int32_t valuebytes) = 0;
     virtual StatusCode Remove(const string &key) = 0; // remove value for key
-    virtual StatusCode AllocValueForKey(const string &key, size_t size,
+    virtual StatusCode AllocValueForKey(int key, size_t size,
                                         char **value) = 0;
 };
 }


### PR DESCRIPTION
This fixes the exception from string constructor when passing non-null terminated stream as key.
Integer value is a temporal solution. Should be changed later to handle
user-defined keys.