### PR TITLE
CMake warnings on LCG93

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,13 @@ If using LCG release, set the desired environment first:
 ```
 . /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_93 x86_64-centos7-gcc7-opt
 ```
+or 
+```
+. /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_latest x86_64-centos7-gcc7-opt
+```
 
 Note: `. scripts/setup_env_lcg.sh` can be called to setup environment with LCG and SPDK.
+Note2: LCG_93 contains CMake 3.7 that may show warnings if BOOST library version is 1.64+.
 
 ##### SPDK
 FogKV is using SPDK internally so following extra step is required to configure environment.

--- a/scripts/setup_env_lcg.sh
+++ b/scripts/setup_env_lcg.sh
@@ -12,5 +12,7 @@ popd  > /dev/null
 SPDKPATH=third-party/spdk
 
 cvmfs_config probe
-source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_93 x86_64-centos7-gcc7-opt
+
+source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_latest x86_64-centos7-gcc7-opt
+
 sudo $SCRIPT_PATH/../$SPDKPATH/scripts/setup.sh


### PR DESCRIPTION
This patch updates setup_env_lcg.sh to use latest LCG with CMake 3.11
and adds explenation about warnings that can be seen on LCG92.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>