### PR TITLE
Forcing to link all DPDK libraries

### DIFF
--- a/apps/minidaq/CMakeLists.txt
+++ b/apps/minidaq/CMakeLists.txt
@@ -13,8 +13,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${ROOT_FOGKV_DIR}/bin)
 
 find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(Threads REQUIRED)
+set(Dpdk_LIBRARIES -Wl,--whole-archive dpdk -Wl,--no-whole-archive)
 
 file(GLOB MINIDAQ_SOURCES *.cpp *.h)
 add_executable(minidaq ${MINIDAQ_SOURCES})
 target_link_libraries(minidaq ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-					  pmem fogkv pmemobj dpdk dl numa z hdr_histogram)
+					  pmem fogkv pmemobj dl numa z hdr_histogram ${Dpdk_LIBRARIES})

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -13,7 +13,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ROOT_FOGKV_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${ROOT_FOGKV_DIR}/bin)
 
 set(3RDPARTY ${ROOT_FOGKV_DIR}/third-party)
+set(Dpdk_LIBRARIES -Wl,--whole-archive dpdk -Wl,--no-whole-archive)
 
 file(GLOB BASIC_SOURCES *.cpp)
 add_executable(basic ${BASIC_SOURCES})
-target_link_libraries(basic ${Boost_LIBRARIES} fogkv pmemobj dpdk dl numa ${CMAKE_THREAD_LIBS_INIT} )
+target_link_libraries(basic ${Boost_LIBRARIES} fogkv pmemobj dl numa ${CMAKE_THREAD_LIBS_INIT} ${Dpdk_LIBRARIES})

--- a/examples/cli_node/CMakeLists.txt
+++ b/examples/cli_node/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ROOT_FOGKV_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${ROOT_FOGKV_DIR}/bin)
 
 set(3RDPARTY ${ROOT_FOGKV_DIR}/third-party)
+set(Dpdk_LIBRARIES -Wl,--whole-archive dpdk -Wl,--no-whole-archive)
 
 find_package(Boost REQUIRED COMPONENTS program_options log log_setup system filesystem thread)
 find_package(Threads REQUIRED)
@@ -26,5 +27,5 @@ add_library(linenoise SHARED linenoise/linenoise.c linenoise/linenoise.h)
 file(GLOB CLINODE_SOURCES ${EXAMPLES}/cli_node/*.cpp ${EXAMPLES}/cli_node/*.h)
 add_executable(clinode ${CLINODE_SOURCES})
 target_link_libraries(clinode ${Jsoncpp_LIBRARY} ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-	fabric pmem fogkv linenoise pmemobj dpdk dl numa)
+	fabric pmem fogkv linenoise pmemobj dl numa ${Dpdk_LIBRARIES})
 

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -67,7 +67,7 @@ ExternalProject_Add(project_spdk
 	PREFIX ${PROJECT_SOURCE_DIR}/spdk
 	SOURCE_DIR ${PROJECT_SOURCE_DIR}/spdk
 	BUILD_IN_SOURCE ${PROJECT_SOURCE_DIR}/spdk
-	CONFIGURE_COMMAND ""
+	CONFIGURE_COMMAND "./configure"
 	BUILD_COMMAND make
 	INSTALL_COMMAND ${ROOT_FOGKV_DIR}/scripts/prepare_spdk_libs.sh
 )


### PR DESCRIPTION
Some DPDK functionalites require to call initializers of sub-libraries