### PR TITLE
cli_node: adding key attrs to put, aput, update, aupdate

### DIFF
--- a/examples/cli_node/nodeCli.cpp
+++ b/examples/cli_node/nodeCli.cpp
@@ -47,10 +47,21 @@ using namespace std;
 using namespace boost::algorithm;
 using boost::format;
 
+#define NUM_ELEM_KEY_ATTRS 3
+#define PUT_CMD_KEY_ATTRS_OFFSET 3
+#define PUT_CMD_VAL_OFFSET 2
+#define UPDATE_CMD_KEY_ATTRS_OFFSET 3
+#define UPDATE_CMD_VAL_OFFSET 2
+#define KEY_ATTRS_OPT_NAME_POS_OFFSET 1
+#define KEY_ATTRS_OPT_VAL_POS_OFFSET 2
+
 map<string, string> consoleCmd =
     boost::assign::map_list_of("help", "")("get", " <key>")("aget", " <key>")(
-        "put", " <key> <value>")("aput", " <key> <value>")("status", "")(
-        "remove", " <key>")("quit", "")("node", " <id>");
+        "put", " <key> <value> [-o <lock|ready|long_term> <0|1>]")(
+        "aput", " <key> <value> [-o <lock|ready|long_term> <0|1>]")(
+        "status", "")("remove", " <key>")("quit", "")("node", " <id>")(
+        "update", " <key> [value] [-o <lock|ready|long_term> <0|1>]")(
+        "aupdate", " <key> [value] [-o <lock|ready|long_term> <0|1>]");
 
 /*!
  * Provides completion functionality to dragon shell.
@@ -65,6 +76,8 @@ void completion(const char *buf, linenoiseCompletions *lc) {
         linenoiseAddCompletion(lc, "quit");
     } else if (buf[0] == 'g') {
         linenoiseAddCompletion(lc, "get");
+    } else if (buf[0] == 'u') {
+        linenoiseAddCompletion(lc, "update");
     } else if (buf[0] == 'p') {
         linenoiseAddCompletion(lc, "put");
     } else if (buf[0] == 's') {
@@ -78,6 +91,8 @@ void completion(const char *buf, linenoiseCompletions *lc) {
             linenoiseAddCompletion(lc, "aget");
         } else if (buf[1] == 'p') {
             linenoiseAddCompletion(lc, "aput");
+        } else if (buf[1] == 'u') {
+            linenoiseAddCompletion(lc, "aupdate");
         }
     }
 }
@@ -130,19 +145,23 @@ int nodeCli::operator()() {
                 cout << "\t- " << cmdEntry.first << cmdEntry.second << endl;
             }
         } else if (starts_with(strLine, "g")) {
-            this->cmdGet(strLine);
+            this->_cmdGet(strLine);
         } else if (starts_with(strLine, "p")) {
-            this->cmdPut(strLine);
+            this->_cmdPut(strLine);
+        } else if (starts_with(strLine, "u")) {
+            this->_cmdUpdate(strLine);
         } else if (starts_with(strLine, "ap")) {
-            this->cmdPutAsync(strLine);
+            this->_cmdPutAsync(strLine);
         } else if (starts_with(strLine, "ag")) {
-            this->cmdGetAsync(strLine);
+            this->_cmdGetAsync(strLine);
+        } else if (starts_with(strLine, "au")) {
+            this->_cmdUpdateAsync(strLine);
         } else if (starts_with(strLine, "r")) {
-            this->cmdRemove(strLine);
+            this->_cmdRemove(strLine);
         } else if (starts_with(strLine, "s")) {
-            this->cmdStatus();
+            this->_cmdStatus();
         } else if (starts_with(strLine, "n")) {
-            this->cmdNodeStatus(strLine);
+            this->_cmdNodeStatus(strLine);
         } else if (starts_with(strLine, "q")) {
             return false;
         } else {
@@ -155,7 +174,7 @@ int nodeCli::operator()() {
     return true;
 }
 
-void nodeCli::cmdGet(const std::string &strLine) {
+void nodeCli::_cmdGet(const std::string &strLine) {
     vector<string> arguments;
     split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
 
@@ -198,7 +217,7 @@ void nodeCli::cmdGet(const std::string &strLine) {
     }
 }
 
-void nodeCli::cmdGetAsync(const std::string &strLine) {
+void nodeCli::_cmdGetAsync(const std::string &strLine) {
     vector<string> arguments;
     split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
 
@@ -241,50 +260,94 @@ void nodeCli::cmdGetAsync(const std::string &strLine) {
     }
 }
 
-FogKV::Key nodeCli::strToKey(const std::string &key) {
+FogKV::Key nodeCli::_strToKey(const std::string &key) {
     FogKV::Key keyBuff = _spKVStore->AllocKey();
     std::memset(keyBuff.data(), 0, keyBuff.size());
     std::memcpy(keyBuff.data(), key.c_str(), key.size());
     return keyBuff;
 }
 
-void nodeCli::cmdPut(const std::string &strLine) {
+FogKV::PrimaryKeyAttribute
+nodeCli::_getKeyAttr(unsigned char start,
+                     const std::vector<std::string> &cmdAttrs) {
+    if ((cmdAttrs.size() < start + NUM_ELEM_KEY_ATTRS) ||
+        !(starts_with(cmdAttrs[start], "-o"))) {
+        return FogKV::PrimaryKeyAttribute::EMPTY;
+    }
+
+    auto optVal = boost::lexical_cast<bool>(
+        cmdAttrs[start + KEY_ATTRS_OPT_VAL_POS_OFFSET]);
+    if (optVal) {
+        string optName = cmdAttrs[start + KEY_ATTRS_OPT_NAME_POS_OFFSET];
+        if (optName == "lock") {
+            return FogKV::PrimaryKeyAttribute::LOCKED;
+        } else if (optName == "ready") {
+            return FogKV::PrimaryKeyAttribute::READY;
+        } else if (optName == "long_term") {
+            return FogKV::PrimaryKeyAttribute::LONG_TERM;
+        }
+    }
+    return FogKV::PrimaryKeyAttribute::EMPTY;
+}
+
+FogKV::PrimaryKeyAttribute
+nodeCli::_getKeyAttrs(unsigned char start,
+                      const std::vector<std::string> &cmdAttrs) {
+    if (cmdAttrs.size() < start + NUM_ELEM_KEY_ATTRS) {
+        return FogKV::PrimaryKeyAttribute::EMPTY;
+    }
+    if ((cmdAttrs.size() - start) % NUM_ELEM_KEY_ATTRS != 0) {
+        cout << "Warning: cannot parse key attributes" << endl;
+        return FogKV::PrimaryKeyAttribute::EMPTY;
+    }
+
+    unsigned char parsingPositon = start;
+    FogKV::PrimaryKeyAttribute result = FogKV::PrimaryKeyAttribute::EMPTY;
+    while (parsingPositon <= cmdAttrs.size()) {
+        result = result | _getKeyAttr(parsingPositon, cmdAttrs);
+        parsingPositon += NUM_ELEM_KEY_ATTRS;
+    }
+
+    return result;
+}
+
+void nodeCli::_cmdPut(const std::string &strLine) {
     vector<string> arguments;
     split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
 
-    if (arguments.size() != 3) {
-        cout << "Error: expects two arguments" << endl;
+    if (arguments.size() < 3) {
+        cout << "Error: expects at least two arguments" << endl;
     } else {
         auto key = arguments[1];
         if (key.size() > _spKVStore->KeySize()) {
-            cout << "Error: kay size is " << _spKVStore->KeySize() << endl;
+            cout << "Error: key size is " << _spKVStore->KeySize() << endl;
             return;
         }
 
         FogKV::Key keyBuff;
         try {
-            keyBuff = strToKey(key);
+            keyBuff = _strToKey(key);
         } catch (...) {
             cout << "Error: cannot allocate key buffer" << endl;
             return;
         }
-
-        auto value = arguments[2];
-
         FogKV::Value valBuff;
         try {
-            valBuff = _spKVStore->Alloc(keyBuff, value.size() + 1);
-            std::memcpy(valBuff.data(), value.c_str(), value.size());
-            valBuff.data()[valBuff.size() - 1] = '\0';
+            valBuff = _allocValue(keyBuff, arguments[PUT_CMD_VAL_OFFSET]);
         } catch (...) {
             cout << "Error: cannot allocate value buffer" << endl;
             _spKVStore->Free(std::move(keyBuff));
             return;
         }
 
+        auto keyAttrs = _getKeyAttrs(PUT_CMD_KEY_ATTRS_OFFSET, arguments);
+        FogKV::PutOptions options(keyAttrs);
+
         try {
-            _spKVStore->Put(std::move(keyBuff), std::move(valBuff));
-            cout << format("Put: [%1%] = %2%\n") % key % value;
+            _spKVStore->Put(std::move(keyBuff), std::move(valBuff),
+                            std::move(options));
+            cout << format("Put: [%1%] = %2% (Opts:%3%)\n") % key %
+                        arguments[PUT_CMD_VAL_OFFSET] % options.Attr;
         } catch (FogKV::OperationFailedException &e) {
             cout << "Error: cannot put element: " << e.status().to_string()
                  << endl;
@@ -299,12 +362,157 @@ void nodeCli::cmdPut(const std::string &strLine) {
     }
 }
 
-void nodeCli::cmdPutAsync(const std::string &strLine) {
+FogKV::Value nodeCli::_strToValue(const std::string &valStr) {
+    Value result;
+    if (!starts_with(valStr, "-o")) {
+        auto buffer = new char[valStr.size() + 1];
+        result = Value(buffer, valStr.size() + 1);
+        std::memcpy(result.data(), valStr.c_str(), valStr.size());
+        result.data()[result.size() - 1] = '\0';
+    }
+    return result;
+}
+
+FogKV::Value nodeCli::_allocValue(const FogKV::Key &key,
+                                 const std::string &valStr) {
+    FogKV::Value result = _spKVStore->Alloc(key, valStr.size() + 1);
+    std::memcpy(result.data(), valStr.c_str(), valStr.size());
+    result.data()[result.size() - 1] = '\0';
+    return result;
+}
+
+void nodeCli::_cmdUpdate(const std::string &strLine) {
     vector<string> arguments;
     split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
 
-    if (arguments.size() != 3) {
-        cout << "Error: expects two arguments" << endl;
+    if (arguments.size() < 2) {
+        cout << "Error: expects at least one argument" << endl;
+    } else {
+        auto key = arguments[1];
+        if (key.size() > _spKVStore->KeySize()) {
+            cout << "Error: key size is " << _spKVStore->KeySize() << endl;
+            return;
+        }
+        FogKV::Key keyBuff;
+        try {
+            keyBuff = _strToKey(key);
+        } catch (...) {
+            cout << "Error: cannot allocate key buffer" << endl;
+            return;
+        }
+
+        FogKV::Value valBuff;
+        unsigned short optionStartPos = UPDATE_CMD_KEY_ATTRS_OFFSET;
+        if (!starts_with(arguments[UPDATE_CMD_VAL_OFFSET], "-o")) {
+            valBuff = _strToValue(arguments[UPDATE_CMD_VAL_OFFSET]);
+        } else {
+            optionStartPos = UPDATE_CMD_VAL_OFFSET;
+        }
+
+        auto keyAttrs = _getKeyAttrs(optionStartPos, arguments);
+        FogKV::UpdateOptions options(keyAttrs);
+
+        try {
+            if (valBuff.size() > 0) {
+                _spKVStore->Update(std::move(keyBuff), std::move(valBuff),
+                                   std::move(options));
+            } else {
+                _spKVStore->Update(std::move(keyBuff), std::move(options));
+            }
+        } catch (FogKV::OperationFailedException &e) {
+            cout << "Error: cannot update element: " << e.status().to_string()
+                 << endl;
+        }
+    }
+}
+
+void nodeCli::_cmdUpdateAsync(const std::string &strLine) {
+    vector<string> arguments;
+    split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
+
+    if (arguments.size() < 2) {
+        cout << "Error: expects at least one argument" << endl;
+    } else {
+        auto key = arguments[1];
+        if (key.size() > _spKVStore->KeySize()) {
+            cout << "Error: key size is " << _spKVStore->KeySize() << endl;
+            return;
+        }
+        FogKV::Key keyBuff;
+        try {
+            keyBuff = _strToKey(key);
+        } catch (...) {
+            cout << "Error: cannot allocate key buffer" << endl;
+            return;
+        }
+
+        FogKV::Value valBuff;
+        unsigned short optionStartPos = UPDATE_CMD_KEY_ATTRS_OFFSET;
+        if (!starts_with(arguments[UPDATE_CMD_VAL_OFFSET], "-o")) {
+            valBuff = _strToValue(arguments[UPDATE_CMD_VAL_OFFSET]);
+        } else {
+            optionStartPos = UPDATE_CMD_VAL_OFFSET;
+        }
+
+        auto keyAttrs = _getKeyAttrs(optionStartPos, arguments);
+        FogKV::UpdateOptions options(keyAttrs);
+
+        try {
+            if (valBuff.size() > 0) {
+                _spKVStore->UpdateAsync(
+                    std::move(keyBuff), std::move(valBuff),
+                    [&](FogKV::KVStoreBase *kvs, FogKV::Status status,
+                        const char *key, const size_t keySize,
+                        const char *value, const size_t valueSize) {
+                        if (!status.ok()) {
+                            _statusMsgs.push_back(boost::str(
+                                boost::format(
+                                    "Error: cannot update element: %1%") %
+                                status.to_string()));
+                        } else {
+                            _statusMsgs.push_back(boost::str(
+                                boost::format(
+                                    "UPDATE[%1%]=%2% (Opts:%3%) : completed") %
+                                key % value % options.Attr));
+                        }
+                        if (keyBuff.size() > 0)
+                            _spKVStore->Free(std::move(keyBuff));
+                    },
+                    std::move(options));
+            } else {
+                _spKVStore->UpdateAsync(
+                    std::move(keyBuff), std::move(options),
+                    [&](FogKV::KVStoreBase *kvs, FogKV::Status status,
+                        const char *key, const size_t keySize,
+                        const char *value, const size_t valueSize) {
+                        if (!status.ok()) {
+                            _statusMsgs.push_back(boost::str(
+                                boost::format(
+                                    "Error: cannot update element: %1%") %
+                                status.to_string()));
+                        } else {
+                            _statusMsgs.push_back(boost::str(
+                                boost::format(
+                                    "UPDATE[%1%]=%2% (Opts:%3%) : completed") %
+                                key % value % options.Attr));
+                        }
+                        if (keyBuff.size() > 0)
+                            _spKVStore->Free(std::move(keyBuff));
+                    });
+            }
+        } catch (FogKV::OperationFailedException &e) {
+            cout << "Error: cannot update element: " << e.status().to_string()
+                 << endl;
+        }
+    }
+}
+
+void nodeCli::_cmdPutAsync(const std::string &strLine) {
+    vector<string> arguments;
+    split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
+
+    if (arguments.size() < 3) {
+        cout << "Error: expects at least two arguments" << endl;
     } else {
         auto key = arguments[1];
         if (key.size() > _spKVStore->KeySize()) {
@@ -314,24 +522,23 @@ void nodeCli::cmdPutAsync(const std::string &strLine) {
 
         FogKV::Key keyBuff;
         try {
-            keyBuff = strToKey(key);
+            keyBuff = _strToKey(key);
         } catch (...) {
             cout << "Error: cannot allocate key buffer" << endl;
             return;
         }
 
-        auto value = arguments[2];
-
         FogKV::Value valBuff;
         try {
-            valBuff = _spKVStore->Alloc(keyBuff, value.size() + 1);
-            std::memcpy(valBuff.data(), value.c_str(), value.size());
-            valBuff.data()[valBuff.size() - 1] = '\0';
+            valBuff = _allocValue(keyBuff, arguments[PUT_CMD_VAL_OFFSET]);
         } catch (...) {
             cout << "Error: cannot allocate value buffer" << endl;
             _spKVStore->Free(std::move(keyBuff));
             return;
         }
+
+        auto keyAttrs = _getKeyAttrs(PUT_CMD_KEY_ATTRS_OFFSET, arguments);
+        FogKV::PutOptions options(keyAttrs);
 
         try {
             _spKVStore->PutAsync(
@@ -345,12 +552,13 @@ void nodeCli::cmdPutAsync(const std::string &strLine) {
                             status.to_string()));
                     } else {
                         _statusMsgs.push_back(boost::str(
-                            boost::format("PUT[%1%]=%2% : completed") % key %
-                            value));
+                            boost::format("PUT[%1%]=%2% (Opts:%3%) : completed") % key %
+                            value % options.Attr));
                     }
                     if (keyBuff.size() > 0)
                         _spKVStore->Free(std::move(keyBuff));
-                });
+                },
+                std::move(options));
         } catch (FogKV::OperationFailedException &e) {
             cout << "Error: cannot put element: " << e.status().to_string()
                  << endl;
@@ -364,7 +572,7 @@ void nodeCli::cmdPutAsync(const std::string &strLine) {
     }
 }
 
-void nodeCli::cmdRemove(const std::string &strLine) {
+void nodeCli::_cmdRemove(const std::string &strLine) {
     vector<string> arguments;
     split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
 
@@ -375,7 +583,7 @@ void nodeCli::cmdRemove(const std::string &strLine) {
         auto key = arguments[1];
         FogKV::Key keyBuff;
         try {
-            keyBuff = strToKey(key);
+            keyBuff = _strToKey(key);
         } catch (...) {
             cout << "Error: cannot allocate key buffer" << endl;
             return;
@@ -403,7 +611,7 @@ Json::Value nodeCli::getPeersJson() {
     return peers;
 }
 
-void nodeCli::cmdStatus() {
+void nodeCli::_cmdStatus() {
     Json::Value peers = getPeersJson();
 
     auto npeers = peers.size();
@@ -432,7 +640,7 @@ void nodeCli::cmdStatus() {
     }
 }
 
-void nodeCli::cmdNodeStatus(const std::string &strLine) {
+void nodeCli::_cmdNodeStatus(const std::string &strLine) {
     vector<string> arguments;
     split(arguments, strLine, is_any_of("\t "), boost::token_compress_on);
 

--- a/examples/cli_node/nodeCli.h
+++ b/examples/cli_node/nodeCli.h
@@ -32,52 +32,57 @@
 
 #pragma once
 
-#include <iostream>
-#include <linenoise.h>
 #include <FogKV/KVStoreBase.h>
+#include <iostream>
 #include <json/json.h>
+#include <linenoise.h>
 #include <memory>
 
-namespace
-{
+namespace {
 const unsigned int consoleHintColor = 35; // dark red
 };
 
-namespace FogKV
-{
+namespace FogKV {
 
 /*!
  * Dragon shell interpreter.
  * Created for test purposes - to allow performing quick testing of the node.
  */
 class nodeCli {
-public:
-	nodeCli(std::shared_ptr<FogKV::KVStoreBase> &spDragonSrv);
-	virtual ~nodeCli();
+  public:
+    nodeCli(std::shared_ptr<FogKV::KVStoreBase> &spDragonSrv);
+    virtual ~nodeCli();
 
-	/*!
-	 * Waiting for user input, executes defined commands
-	 *
-	 * @return false if user choose "quit" command, otherwise true
-	 */
-	int operator()();
+    /*!
+     * Waiting for user input, executes defined commands
+     *
+     * @return false if user choose "quit" command, otherwise true
+     */
+    int operator()();
 
-private:
-	void cmdGet(const std::string &strLine);
-	void cmdGetAsync(const std::string &strLine);
-	void cmdPut(const std::string &strLine);
-	void cmdPutAsync(const std::string &strLine);
-	void cmdRemove(const std::string &strLine);
-	void cmdStatus();
-	void cmdNodeStatus(const std::string &strLine);
+  private:
+    void _cmdGet(const std::string &strLine);
+    void _cmdGetAsync(const std::string &strLine);
+    void _cmdPut(const std::string &strLine);
+    void _cmdPutAsync(const std::string &strLine);
+    void _cmdUpdate(const std::string &strLine);
+    void _cmdUpdateAsync(const std::string &strLine);
+    void _cmdRemove(const std::string &strLine);
+    void _cmdStatus();
+    void _cmdNodeStatus(const std::string &strLine);
 
-	FogKV::Key strToKey(const std::string &key);
-	FogKV::Value strToValue(const std::string &val);
+    FogKV::Key _strToKey(const std::string &key);
+    FogKV::Value _strToValue(const std::string &valStr);
+    FogKV::Value _allocValue(const FogKV::Key &key, const std::string &valStr);
 
-	std::shared_ptr<FogKV::KVStoreBase> _spKVStore;
-	std::vector<std::string> _statusMsgs;
+    FogKV::PrimaryKeyAttribute
+    _getKeyAttrs(unsigned char start, const std::vector<std::string> &cmdAttrs);
+    FogKV::PrimaryKeyAttribute
+    _getKeyAttr(unsigned char start, const std::vector<std::string> &cmdAttrs);
 
-	Json::Value getPeersJson();
+    std::shared_ptr<FogKV::KVStoreBase> _spKVStore;
+    std::vector<std::string> _statusMsgs;
+
+    Json::Value getPeersJson();
 };
-
 }

--- a/include/FogKV/KVStoreBase.h
+++ b/include/FogKV/KVStoreBase.h
@@ -62,21 +62,13 @@ namespace FogKV {
  */
 class KVStoreBase {
   public:
-	/** @TODO: jradtke Temporarily using this base alias for both PUT and GET messages */
+	/** @TODO: jradtke Temporarily using this base alias for both PUT,GET,UPDATE messages */
     using KVStoreBaseCallback = std::function<void(
         KVStoreBase *kvs, Status status, const char *key, const size_t keySize,
         const char *value, const size_t valueSize)>;
 
-    using KVStoreBasePutCallback = std::function<void(
-        KVStoreBase *kvs, Status status, const char *key, const size_t keySize,
-        const char *value, const size_t valueSize)>;
-    using KVStoreBaseGetCallback = std::function<void(
-        KVStoreBase *kvs, Status status, const char *key, const size_t keySize,
-        char *value, size_t valueSize)>;
     using KVStoreBaseGetAnyCallback =
         std::function<void(KVStoreBase *kvs, Status status, const Key &key)>;
-    using KVStoreBaseUpdateCallback = std::function<void(
-        KVStoreBase *kvs, Status status, const Key &key, const Value &value)>;
     using KVStoreBaseRangeCallback = std::function<void(
         KVStoreBase *kvs, Status status, std::vector<KVPair> &results)>;
 
@@ -124,9 +116,9 @@ class KVStoreBase {
      *
      * @param[in] key Rvalue reference to key buffer.
      * @param[in] value Rvalue reference to value buffer
-     * @param[in] options Put opration options.
+     * @param[in] options Put operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      * @snippet basic/basic.cpp key_struct
      * @snippet basic/basic.cpp put
@@ -146,7 +138,7 @@ class KVStoreBase {
      * completes with results passed in arguments.
      * @param[in] options Put operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      * @snippet basic/basic.cpp key_struct
      * @snippet basic/basic.cpp put_async
@@ -163,7 +155,7 @@ class KVStoreBase {
      * @param[in] key Reference to a key structure.
      * @param[in] options Get operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      * @snippet basic/basic.cpp key_struct
      * @snippet basic/basic.cpp get
@@ -204,7 +196,7 @@ class KVStoreBase {
      * completes with results passed in arguments.
      * @param[in] options Get operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      * @snippet basic/basic.cpp key_struct
      * @snippet basic/basic.cpp get_async
@@ -222,7 +214,7 @@ class KVStoreBase {
      * @param[in] value Rvalue reference to a value buffer.
      * @param[in] options Update operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual void Update(const Key &key, Value &&value,
@@ -234,7 +226,7 @@ class KVStoreBase {
      * @param[in] key Reference to a key buffer.
      * @param[in] options Update operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual void Update(const Key &key, const UpdateOptions &options) = 0;
@@ -251,11 +243,11 @@ class KVStoreBase {
      * completes with results passed in arguments.
      * @param[in] options Update operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual void
-    UpdateAsync(const Key &key, Value &&value, KVStoreBaseUpdateCallback cb,
+    UpdateAsync(const Key &key, Value &&value, KVStoreBaseCallback cb,
                 const UpdateOptions &options = UpdateOptions()) = 0;
 
     /**
@@ -269,11 +261,11 @@ class KVStoreBase {
      * completes with results passed in arguments.
      * @param[in] options Update operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual void UpdateAsync(const Key &key, const UpdateOptions &options,
-                             KVStoreBaseUpdateCallback cb) = 0;
+                             KVStoreBaseCallback cb) = 0;
 
     /**
      * Synchronously get values for a given range of keys.
@@ -285,7 +277,7 @@ class KVStoreBase {
      * @param[in] end key representing the end of a range.
      * @param[in] options Get operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual std::vector<KVPair>
@@ -301,7 +293,7 @@ class KVStoreBase {
      * completes with results passed in arguments.
      * @param[in] options Get operation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual void GetRangeAsync(const Key &beg, const Key &end,
@@ -313,7 +305,7 @@ class KVStoreBase {
      *
      * @param[in] key Pointer to a key structure.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      */
     virtual void Remove(const Key &key) = 0;
 
@@ -325,7 +317,7 @@ class KVStoreBase {
      * @param[in] end Pointer to a key structure representing the end of a
      * range.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      */
     virtual void RemoveRange(const Key &beg, const Key &end) = 0;
 
@@ -358,7 +350,7 @@ class KVStoreBase {
      * not nullptr, this call is equivalent to Free.
      * @param[in] options New options for a Value buffer.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      * @note It is possible to modify the options of an allocation without
      * changing a size, by passing the same size.
@@ -373,7 +365,7 @@ class KVStoreBase {
      * @param[in] value Value buffer.
      * @param[in] options Allocation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual void ChangeOptions(Value &value, const AllocOptions &options) = 0;
@@ -392,7 +384,7 @@ class KVStoreBase {
      * Deallocate a Key buffer.
      *
      * @param[in] key Key buffer. If not allocated by current instance of
-     * KVStoreBase the behaviour is undefined.
+     * KVStoreBase the behavior is undefined.
      */
     virtual void Free(Key &&key) = 0;
 
@@ -402,7 +394,7 @@ class KVStoreBase {
      * @param[in] key Key buffer.
      * @param[in] options Allocation options.
      *
-     * @throw OperationFailedException if any error occured XXX
+     * @throw OperationFailedException if any error occurred XXX
      *
      */
     virtual void ChangeOptions(Key &key, const AllocOptions &options) = 0;

--- a/include/FogKV/Options.h
+++ b/include/FogKV/Options.h
@@ -40,9 +40,11 @@
 
 namespace FogKV {
 
-enum PrimaryKeyAttribute {
-    LOCKED = 0x1,
-    READY = 0x2,
+enum PrimaryKeyAttribute : std::int8_t {
+    EMPTY       = 0,
+    LOCKED      = (1 << 0),
+    READY       = (1 << 1),
+    LONG_TERM   = (1 << 2)
 };
 
 inline PrimaryKeyAttribute operator|(PrimaryKeyAttribute a,
@@ -61,6 +63,9 @@ struct UpdateOptions {
 };
 
 struct PutOptions {
+    PutOptions() {}
+    PutOptions(PrimaryKeyAttribute attr) : Attr(attr) {}
+
     void poolerId(unsigned short id) { _poolerId = id; }
 
     void roundRobin(bool rr) { _roundRobin = rr; }
@@ -69,6 +74,7 @@ struct PutOptions {
 
     bool roundRobin() const { return _roundRobin; }
 
+    PrimaryKeyAttribute Attr;
     unsigned short _poolerId = 0;
     bool _roundRobin = true;
 };

--- a/lib/store/KVStoreBaseImpl.cpp
+++ b/lib/store/KVStoreBaseImpl.cpp
@@ -147,10 +147,7 @@ void KVStoreBaseImpl::GetAnyAsync(KVStoreBaseGetAnyCallback cb,
 void KVStoreBaseImpl::Update(const Key &key, Value &&val,
                              const UpdateOptions &options) {
 
-    StatusCode rc = mRTree->Put(key.data(), val.data());
-
-    if (rc != StatusCode::Ok)
-        throw OperationFailedException(EINVAL);
+    throw FUNC_NOT_IMPLEMENTED;
 }
 
 void KVStoreBaseImpl::Update(const Key &key, const UpdateOptions &options) {
@@ -158,20 +155,13 @@ void KVStoreBaseImpl::Update(const Key &key, const UpdateOptions &options) {
 }
 
 void KVStoreBaseImpl::UpdateAsync(const Key &key, Value &&value,
-                                  KVStoreBaseUpdateCallback cb,
+                                  KVStoreBaseCallback cb,
                                   const UpdateOptions &options) {
-    std::async(std::launch::async, [&] {
-        try {
-            Update(key, std::move(value));
-            cb(this, StatusCode::Ok, key, value);
-        } catch (OperationFailedException &e) {
-            cb(this, e.status(), key, value);
-        }
-    });
+    throw FUNC_NOT_IMPLEMENTED;
 }
 
 void KVStoreBaseImpl::UpdateAsync(const Key &key, const UpdateOptions &options,
-                                  KVStoreBaseUpdateCallback cb) {
+                                  KVStoreBaseCallback cb) {
     throw FUNC_NOT_IMPLEMENTED;
 }
 

--- a/lib/store/KVStoreBaseImpl.h
+++ b/lib/store/KVStoreBaseImpl.h
@@ -60,10 +60,10 @@ class KVStoreBaseImpl : public KVStoreBase {
                         const UpdateOptions &options = UpdateOptions());
     virtual void Update(const Key &key, const UpdateOptions &options);
     virtual void UpdateAsync(const Key &key, Value &&value,
-                             KVStoreBaseUpdateCallback cb,
+                             KVStoreBaseCallback cb,
                              const UpdateOptions &options = UpdateOptions());
     virtual void UpdateAsync(const Key &key, const UpdateOptions &options,
-                             KVStoreBaseUpdateCallback cb);
+                             KVStoreBaseCallback cb);
     virtual std::vector<KVPair>
     GetRange(const Key &beg, const Key &end,
              const GetOptions &options = GetOptions());


### PR DESCRIPTION
This patch adds support for setting key attributes thru put and update
commands in cli_node example.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>