### PR TITLE
spdk offload: Move request pooler to reactor

### DIFF
--- a/lib/store/KVStoreBaseImpl.cpp
+++ b/lib/store/KVStoreBaseImpl.cpp
@@ -337,8 +337,10 @@ void KVStoreBaseImpl::init() {
         _rqstPoolers.push_back(
             new FogKV::RqstPooler(mRTree, POOLER_CPU_CORE_BASE + index));
     }
-    _offloadPooler =
-        new FogKV::OffloadRqstPooler(POOLER_CPU_CORE_BASE + poolerCount + 2);
+
+    _offloadPooler = new FogKV::OffloadRqstPooler();
+
+    _offloadReactor->RegisterPooler(_offloadPooler);
 
     FOG_DEBUG("KVStoreBaseImpl initialization completed");
 }

--- a/lib/store/OffloadReactor.h
+++ b/lib/store/OffloadReactor.h
@@ -44,32 +44,29 @@
 
 #include <functional>
 
+#include "OffloadRqstPooler.h"
+
 namespace FogKV {
 
 using OffloadReactorShutdownCallback = std::function<void()>;
 
-/** Intarface has been created to enable mocking in unit tests */
-class OffloadReactorInterface {
-    virtual void StartThread() = 0;
-};
+void reactor_start_clb(void *offload_reactor, void *arg2);
+int reactor_pooler_fn(void *offload_reactor);
 
-class OffloadReactor : public OffloadReactorInterface {
+class OffloadReactor {
   public:
     OffloadReactor(const size_t cpuCore = 0, std::string spdkConfigFile = "",
                    OffloadReactorShutdownCallback clb = nullptr);
     virtual ~OffloadReactor();
 
+    void RegisterPooler(OffloadRqstPooler *offloadPooler);
     void StartThread();
 
     std::atomic<int> isRunning;
+    std::vector<OffloadRqstPooler *> rqstPoolers;
 
   private:
     void _ThreadMain(void);
-
-    /** declared as static to allow using by SPDK */
-    static void Shutdown(void);
-    /** declared as static to allow using by SPDK */
-    static void Start(void *arg1, void *arg2);
 
     std::string _spdkConfigFile;
     std::unique_ptr<spdk_app_opts> _spdkAppOpts;

--- a/lib/store/OffloadRqstPooler.h
+++ b/lib/store/OffloadRqstPooler.h
@@ -66,8 +66,6 @@ class OffloadRqstMsg {
 };
 
 class OffloadRqstPoolerInterface {
-    virtual void StartThread() = 0;
-
     virtual bool EnqueueMsg(OffloadRqstMsg *Message) = 0;
     virtual void DequeueMsg() = 0;
     virtual void ProcessMsg() = 0;
@@ -75,25 +73,19 @@ class OffloadRqstPoolerInterface {
 
 class OffloadRqstPooler : public OffloadRqstPoolerInterface {
   public:
-    OffloadRqstPooler(const size_t cpuCore = 0);
+    OffloadRqstPooler();
     virtual ~OffloadRqstPooler();
 
     bool EnqueueMsg(OffloadRqstMsg *Message);
     void DequeueMsg();
     void ProcessMsg() final;
-    void StartThread();
 
-    std::atomic<int> isRunning;
     struct spdk_ring *rqstRing;
 
     unsigned short processArrayCount = 0;
     OffloadRqstMsg *processArray[OFFLOAD_DEQUEUE_RING_LIMIT];
 
   private:
-    void _ThreadMain(void);
-
-    std::thread *_thread;
-    size_t _cpuCore = 0;
     struct spdk_bdev *_bdev;
 };
 


### PR DESCRIPTION
This patch moves offload request pooling from separate thread to
spdk reactor.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>