### PR TITLE
setup_env_lcg.sh: change LCG from latest to 93

### DIFF
--- a/scripts/setup_env_lcg.sh
+++ b/scripts/setup_env_lcg.sh
@@ -13,6 +13,6 @@ SPDKPATH=third-party/spdk
 
 cvmfs_config probe
 
-source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_latest x86_64-centos7-gcc7-opt
+source /cvmfs/sft.cern.ch/lcg/views/setupViews.sh LCG_93 x86_64-centos7-gcc7-opt
 
 sudo $SCRIPT_PATH/../$SPDKPATH/scripts/setup.sh


### PR DESCRIPTION
There is issue with latest LCG and CMake, this patch change environment
to LCG93 where all works well.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>