### PR TITLE
fogkv to daqdb renaming - main namespace and API

### DIFF
--- a/apps/minidaq/MinidaqAroNode.cpp
+++ b/apps/minidaq/MinidaqAroNode.cpp
@@ -15,7 +15,7 @@
 
 #include "MinidaqAroNode.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 MinidaqAroNode::MinidaqAroNode(KVStoreBase *kvs) : MinidaqRoNode(kvs) {}
 
@@ -29,12 +29,12 @@ void MinidaqAroNode::_Task(MinidaqKey &key, std::atomic<std::uint64_t> &cnt,
     MinidaqKey *keyTmp = new MinidaqKey;
     *keyTmp = key;
     Key fogKey(reinterpret_cast<char *>(keyTmp), sizeof(*keyTmp));
-    FogKV::Value value = _kvs->Alloc(fogKey, _fSize);
+    DaqDB::Value value = _kvs->Alloc(fogKey, _fSize);
     while (1) {
         try {
             _kvs->PutAsync(std::move(fogKey), std::move(value),
                            [keyTmp, &cnt, &cntErr](
-                               FogKV::KVStoreBase *kvs, FogKV::Status status,
+                               DaqDB::KVStoreBase *kvs, DaqDB::Status status,
                                const char *key, const size_t keySize,
                                const char *value, const size_t valueSize) {
                                if (!status.ok()) {

--- a/apps/minidaq/MinidaqAroNode.h
+++ b/apps/minidaq/MinidaqAroNode.h
@@ -17,7 +17,7 @@
 
 #include "MinidaqRoNode.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 class MinidaqAroNode : public MinidaqRoNode {
   public:

--- a/apps/minidaq/MinidaqFfNode.cpp
+++ b/apps/minidaq/MinidaqFfNode.cpp
@@ -16,7 +16,7 @@
 #include "MinidaqFfNode.h"
 #include <random>
 
-namespace FogKV {
+namespace DaqDB {
 
 /** @todo conisder moving to a new MinidaqSelector class */
 thread_local std::mt19937 _generator;
@@ -79,7 +79,7 @@ void MinidaqFfNode::_Task(MinidaqKey &key, std::atomic<std::uint64_t> &cnt,
     for (int i = 0; i < _PickNFragments(); i++) {
         /** @todo change to GetRange once implemented */
         key.subdetectorId = baseId + i;
-        FogKV::Value value = _kvs->Get(fogKey);
+        DaqDB::Value value = _kvs->Get(fogKey);
         if (*(reinterpret_cast<uint64_t *>(value.data())) != key.eventId) {
             cntErr++;
         } else {
@@ -89,7 +89,7 @@ void MinidaqFfNode::_Task(MinidaqKey &key, std::atomic<std::uint64_t> &cnt,
                         _kvs->UpdateAsync(
                             std::move(fogKey), UpdateOptions(LONG_TERM),
                             [keyTmp, &cnt, &cntErr](
-                                FogKV::KVStoreBase *kvs, FogKV::Status status,
+                                DaqDB::KVStoreBase *kvs, DaqDB::Status status,
                                 const char *key, const size_t keySize,
                                 const char *value, const size_t valueSize) {
                                 if (!status.ok()) {

--- a/apps/minidaq/MinidaqFfNode.h
+++ b/apps/minidaq/MinidaqFfNode.h
@@ -17,7 +17,7 @@
 
 #include "MinidaqNode.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 class MinidaqFfNode : public MinidaqNode {
   public:

--- a/apps/minidaq/MinidaqNode.cpp
+++ b/apps/minidaq/MinidaqNode.cpp
@@ -26,7 +26,7 @@
 #include "MinidaqNode.h"
 #include "MinidaqTimerHR.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 MinidaqNode::MinidaqNode(KVStoreBase *kvs)
     : _kvs(kvs), _stopped(false), _statsReady(false) {}

--- a/apps/minidaq/MinidaqNode.h
+++ b/apps/minidaq/MinidaqNode.h
@@ -20,10 +20,10 @@
 #include <string>
 #include <vector>
 
-#include "FogKV/KVStoreBase.h"
+#include "daqdb/KVStoreBase.h"
 #include "MinidaqStats.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 #define FOGKV_KEY_SIZE 24ull
 #define FOGKV_MAX_PRIMARY_ID ((1ull << FOGKV_KEY_SIZE) - 1ull)

--- a/apps/minidaq/MinidaqRoNode.cpp
+++ b/apps/minidaq/MinidaqRoNode.cpp
@@ -15,7 +15,7 @@
 
 #include "MinidaqRoNode.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 MinidaqRoNode::MinidaqRoNode(KVStoreBase *kvs) : MinidaqNode(kvs) {}
 
@@ -34,7 +34,7 @@ void MinidaqRoNode::_NextKey(MinidaqKey &key) { key.eventId += _nTh; }
 void MinidaqRoNode::_Task(MinidaqKey &key, std::atomic<std::uint64_t> &cnt,
                           std::atomic<std::uint64_t> &cntErr) {
     Key fogKey(reinterpret_cast<char *>(&key), sizeof(key));
-    FogKV::Value value = _kvs->Alloc(fogKey, _fSize);
+    DaqDB::Value value = _kvs->Alloc(fogKey, _fSize);
     *(reinterpret_cast<uint64_t *>(value.data())) = key.eventId;
     _kvs->Put(std::move(fogKey), std::move(value));
     cnt++;

--- a/apps/minidaq/MinidaqRoNode.h
+++ b/apps/minidaq/MinidaqRoNode.h
@@ -17,7 +17,7 @@
 
 #include "MinidaqNode.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 class MinidaqRoNode : public MinidaqNode {
   public:

--- a/apps/minidaq/MinidaqStats.cpp
+++ b/apps/minidaq/MinidaqStats.cpp
@@ -40,7 +40,7 @@
 
 using namespace std;
 
-namespace FogKV {
+namespace DaqDB {
 
 MinidaqStats::MinidaqStats() {
     int err;

--- a/apps/minidaq/MinidaqStats.h
+++ b/apps/minidaq/MinidaqStats.h
@@ -20,7 +20,7 @@
 #include <time.h>
 #include <vector>
 
-namespace FogKV {
+namespace DaqDB {
 
 enum MinidaqMetricType {
     MINIDAQ_METRIC_RPS,

--- a/apps/minidaq/MinidaqTimer.cpp
+++ b/apps/minidaq/MinidaqTimer.cpp
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-namespace FogKV {
+namespace DaqDB {
 
 MinidaqTimer::MinidaqTimer() {}
 

--- a/apps/minidaq/MinidaqTimer.h
+++ b/apps/minidaq/MinidaqTimer.h
@@ -17,7 +17,7 @@
 
 #include <cstdint>
 
-namespace FogKV {
+namespace DaqDB {
 
 class MinidaqTimer {
   public:

--- a/apps/minidaq/MinidaqTimerHR.cpp
+++ b/apps/minidaq/MinidaqTimerHR.cpp
@@ -15,7 +15,7 @@
 
 #include "MinidaqTimerHR.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 MinidaqTimerHR::MinidaqTimerHR() {}
 

--- a/apps/minidaq/MinidaqTimerHR.h
+++ b/apps/minidaq/MinidaqTimerHR.h
@@ -19,7 +19,7 @@
 
 #include "MinidaqTimer.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 class MinidaqTimerHR : public MinidaqTimer {
   public:

--- a/apps/minidaq/minidaq.cpp
+++ b/apps/minidaq/minidaq.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <memory>
 
-#include "FogKV/KVStoreBase.h"
+#include "daqdb/KVStoreBase.h"
 #include "MinidaqAroNode.h"
 #include "MinidaqFfNode.h"
 #include "MinidaqRoNode.h"
@@ -71,20 +71,20 @@ static void logStd(std::string m) {
 }
 
 /** @todo move to MinidaqFogServer for distributed version */
-static FogKV::KVStoreBase *openKVS() {
-    FogKV::Options options;
+static DaqDB::KVStoreBase *openKVS() {
+    DaqDB::Options options;
     options.PMEM.Path = pmem_path;
     options.PMEM.Size = pmem_size;
-    options.Key.field(0, sizeof(FogKV::MinidaqKey::eventId), true);
-    options.Key.field(1, sizeof(FogKV::MinidaqKey::subdetectorId));
-    options.Key.field(2, sizeof(FogKV::MinidaqKey::runId));
+    options.Key.field(0, sizeof(DaqDB::MinidaqKey::eventId), true);
+    options.Key.field(1, sizeof(DaqDB::MinidaqKey::subdetectorId));
+    options.Key.field(2, sizeof(DaqDB::MinidaqKey::runId));
     options.Runtime.numOfPoolers = nPoolers;
     options.Runtime.spdkConfigFile = spdk_conf;
     if (enableLog) {
         options.Runtime.logFunc = logStd;
     }
 
-    return FogKV::KVStoreBase::Open(options);
+    return DaqDB::KVStoreBase::Open(options);
 }
 
 static uint64_t calcIterations() {
@@ -93,7 +93,7 @@ static uint64_t calcIterations() {
 }
 
 static void
-runBenchmark(std::vector<std::unique_ptr<FogKV::MinidaqNode>> &nodes) {
+runBenchmark(std::vector<std::unique_ptr<DaqDB::MinidaqNode>> &nodes) {
     int nCoresUsed = 0;
 
     // Configure
@@ -141,7 +141,7 @@ runBenchmark(std::vector<std::unique_ptr<FogKV::MinidaqNode>> &nodes) {
 
 int main(int argc, const char *argv[]) {
     bool isParallel = MINIDAQ_DEFAULT_PARALLEL;
-    FogKV::KVStoreBase *kvs;
+    DaqDB::KVStoreBase *kvs;
     double acceptLevel;
     int startSubId;
     size_t fSize;
@@ -270,7 +270,7 @@ int main(int argc, const char *argv[]) {
         std::cout << "### Opening FogKV..." << endl;
         kvs = openKVS();
         std::cout << "### Done." << endl;
-        std::vector<std::unique_ptr<FogKV::MinidaqNode>>
+        std::vector<std::unique_ptr<DaqDB::MinidaqNode>>
             nodes; // Configure nodes
         if (nRoTh) {
             std::cout << "### Configuring readout nodes..." << endl;
@@ -278,8 +278,8 @@ int main(int argc, const char *argv[]) {
                 std::cout << "Cannot mix readout modes." << endl;
                 return 0;
             }
-            unique_ptr<FogKV::MinidaqRoNode> nodeRo(
-                new FogKV::MinidaqRoNode(kvs));
+            unique_ptr<DaqDB::MinidaqRoNode> nodeRo(
+                new DaqDB::MinidaqRoNode(kvs));
             nodeRo->SetSubdetectorId(subId);
             nodeRo->SetThreads(nRoTh);
             nodeRo->SetFragmentSize(fSize);
@@ -294,8 +294,8 @@ int main(int argc, const char *argv[]) {
                 std::cout << "Cannot mix readout modes." << endl;
                 return 0;
             }
-            unique_ptr<FogKV::MinidaqAroNode> nodeAro(
-                new FogKV::MinidaqAroNode(kvs));
+            unique_ptr<DaqDB::MinidaqAroNode> nodeAro(
+                new DaqDB::MinidaqAroNode(kvs));
             nodeAro->SetSubdetectorId(subId);
             nodeAro->SetThreads(nAroTh);
             nodeAro->SetFragmentSize(fSize);
@@ -311,8 +311,8 @@ int main(int argc, const char *argv[]) {
 
         if (nFfTh) {
             std::cout << "### Configuring fast-filtering nodes..." << endl;
-            unique_ptr<FogKV::MinidaqFfNode> nodeFf(
-                new FogKV::MinidaqFfNode(kvs));
+            unique_ptr<DaqDB::MinidaqFfNode> nodeFf(
+                new DaqDB::MinidaqFfNode(kvs));
             nodeFf->SetBaseSubdetectorId(startSubId);
             nodeFf->SetSubdetectors(nSub);
             nodeFf->SetThreads(nFfTh);

--- a/apps/mist/config.h
+++ b/apps/mist/config.h
@@ -33,10 +33,10 @@
 #include <iostream>
 #include <vector>
 #include <libconfig.h++>
-#include <FogKV/KVStoreBase.h>
+#include <daqdb/KVStoreBase.h>
 using namespace libconfig;
 using namespace std;
-using namespace FogKV;
+using namespace DaqDB;
 
 class Configuration {
 	private:

--- a/apps/mist/mist.cpp
+++ b/apps/mist/mist.cpp
@@ -33,7 +33,7 @@
 #include <iostream>
 #include <iomanip>
 #include "config.h"
-#include <FogKV/KVStoreBase.h>
+#include <daqdb/KVStoreBase.h>
 #include <asio/io_service.hpp>
 #include <boost/bind.hpp>
 #include <asio/ip/tcp.hpp>
@@ -56,7 +56,7 @@ int main(int argc, char ** argv) {
 	asio::signal_set signals(io_service, SIGINT, SIGTERM);
 	signals.async_wait(boost::bind(&asio::io_service::stop, &io_service));
 
-	FogKV::KVStoreBase *kvs;
+	DaqDB::KVStoreBase *kvs;
 	try {
 		kvs = KVStoreBase::Open(options);
 	} catch (OperationFailedException e) {

--- a/daqdb.Doxyfile
+++ b/daqdb.Doxyfile
@@ -17,7 +17,7 @@ DOXYFILE_ENCODING = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME = "FogKV"
+PROJECT_NAME = "DaqDB"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/examples/basic/basic.cpp
+++ b/examples/basic/basic.cpp
@@ -13,7 +13,7 @@
  * stated in the License.
  */
 
-#include "FogKV/KVStoreBase.h"
+#include "daqdb/KVStoreBase.h"
 
 #include <assert.h>
 #include <cstring>
@@ -35,17 +35,17 @@ struct Key {
 int KVStoreBaseExample() {
     // Open KV store
     //! [open]
-    FogKV::Options options;
+    DaqDB::Options options;
 
     // Configure key structure
     options.Key.field(0, sizeof(Key::event_id), true); // primary key
     options.Key.field(1, sizeof(Key::subdetector_id));
     options.Key.field(2, sizeof(Key::run_id));
 
-    FogKV::KVStoreBase *kvs;
+    DaqDB::KVStoreBase *kvs;
     try {
-        kvs = FogKV::KVStoreBase::Open(options);
-    } catch (FogKV::OperationFailedException &e) {
+        kvs = DaqDB::KVStoreBase::Open(options);
+    } catch (DaqDB::OperationFailedException &e) {
         // error
         // e.status()
     }
@@ -56,7 +56,7 @@ int KVStoreBaseExample() {
 
     //! [put]
     try {
-        FogKV::Key key = kvs->AllocKey();
+        DaqDB::Key key = kvs->AllocKey();
 
         // Fill the key
         Key *keyp = reinterpret_cast<Key *>(key.data());
@@ -64,7 +64,7 @@ int KVStoreBaseExample() {
         keyp->run_id = 2;
         keyp->event_id = 3;
 
-        FogKV::Value value = kvs->Alloc(key, 1024);
+        DaqDB::Value value = kvs->Alloc(key, 1024);
 
         // Fil the value buffer
         std::memset(value.data(), 0, value.size());
@@ -78,7 +78,7 @@ int KVStoreBaseExample() {
 
     //! [put_async]
     try {
-        FogKV::Key key = kvs->AllocKey();
+        DaqDB::Key key = kvs->AllocKey();
 
         // Fill the key
         Key *keyp = reinterpret_cast<Key *>(key.data());
@@ -86,7 +86,7 @@ int KVStoreBaseExample() {
         keyp->run_id = 2;
         keyp->event_id = 3;
 
-        FogKV::Value value = kvs->Alloc(key, 1024);
+        DaqDB::Value value = kvs->Alloc(key, 1024);
 
         // Fill the value buffer
         std::memset(value.data(), 0, value.size());
@@ -94,7 +94,7 @@ int KVStoreBaseExample() {
         // Asynchronous Put operation, transfer ownership of key and value
         // buffers to library
         kvs->PutAsync(std::move(key), std::move(value),
-                      [&](FogKV::KVStoreBase *kvs, FogKV::Status status,
+                      [&](DaqDB::KVStoreBase *kvs, DaqDB::Status status,
                           const char *key, size_t keySize, const char *value,
                           size_t valueSize) {
                           if (!status.ok()) {
@@ -111,7 +111,7 @@ int KVStoreBaseExample() {
     //! [get]
     try {
 
-        FogKV::Key key = kvs->AllocKey();
+        DaqDB::Key key = kvs->AllocKey();
 
         // Fill the key
         Key *keyp = reinterpret_cast<Key *>(key.data());
@@ -123,7 +123,7 @@ int KVStoreBaseExample() {
         // of the value. The caller must free both key and value buffers by
         // itself, or
         // transfer the ownership in another call.
-        FogKV::Value value;
+        DaqDB::Value value;
         try {
             value = kvs->Get(key);
         } catch (...) {
@@ -141,7 +141,7 @@ int KVStoreBaseExample() {
 
     //! [get_async]
     try {
-        FogKV::Key key = kvs->AllocKey();
+        DaqDB::Key key = kvs->AllocKey();
 
         // Fill the key
         Key *keyp = reinterpret_cast<Key *>(key.data());
@@ -151,7 +151,7 @@ int KVStoreBaseExample() {
 
         try {
             kvs->GetAsync(key,
-                          [&](FogKV::KVStoreBase *kvs, FogKV::Status status,
+                          [&](DaqDB::KVStoreBase *kvs, DaqDB::Status status,
                               const char *key, size_t keySize,
                               const char *value, size_t valueSize) {
 
@@ -164,7 +164,7 @@ int KVStoreBaseExample() {
 
                               // free the value buffer
                           });
-        } catch (FogKV::OperationFailedException exc) {
+        } catch (DaqDB::OperationFailedException exc) {
             // error, status in:
             // exc.status();
             kvs->Free(std::move(key));
@@ -177,12 +177,12 @@ int KVStoreBaseExample() {
     //! [get_any]
     try {
 
-        FogKV::GetOptions getOptions;
-        getOptions.Attr = FogKV::READY;
-        getOptions.NewAttr = FogKV::LOCKED | FogKV::READY;
+        DaqDB::GetOptions getOptions;
+        getOptions.Attr = DaqDB::READY;
+        getOptions.NewAttr = DaqDB::LOCKED | DaqDB::READY;
 
         // get and lock any primary key which is in unlocked state
-        FogKV::Key keyBuff = kvs->GetAny(getOptions);
+        DaqDB::Key keyBuff = kvs->GetAny(getOptions);
         Key *key = reinterpret_cast<Key *>(keyBuff.data());
 
         Key keyBeg(key->event_id, std::numeric_limits<uint16_t>::min(),
@@ -191,13 +191,13 @@ int KVStoreBaseExample() {
         Key keyEnd(key->event_id, std::numeric_limits<uint16_t>::max(),
                    std::numeric_limits<uint16_t>::max());
 
-        std::vector<FogKV::KVPair> range = kvs->GetRange(
-            FogKV::Key(reinterpret_cast<char *>(&keyBeg), sizeof(keyBeg)),
-            FogKV::Key(reinterpret_cast<char *>(&keyEnd), sizeof(keyEnd)));
+        std::vector<DaqDB::KVPair> range = kvs->GetRange(
+            DaqDB::Key(reinterpret_cast<char *>(&keyBeg), sizeof(keyBeg)),
+            DaqDB::Key(reinterpret_cast<char *>(&keyEnd), sizeof(keyEnd)));
 
         for (auto kv : range) {
             // or unlock and mark the primary key as ready
-            kvs->Update(kv.key(), FogKV::READY);
+            kvs->Update(kv.key(), DaqDB::READY);
         }
 
     } catch (...) {

--- a/examples/cli_node/node.cpp
+++ b/examples/cli_node/node.cpp
@@ -35,7 +35,7 @@
 
 #include <atomic>
 
-#include <FogKV/KVStoreBase.h>
+#include <daqdb/KVStoreBase.h>
 
 #include "nodeCli.h"
 
@@ -118,7 +118,7 @@ int main(int argc, const char *argv[]) {
         return -1;
     }
 
-    FogKV::Options options;
+    DaqDB::Options options;
 
     std::atomic<int> isRunning; // used to catch SIGTERM, SIGINT
     isRunning = 1;
@@ -136,11 +136,11 @@ int main(int argc, const char *argv[]) {
     options.PMEM.Size = pmem_size;
     options.Key.field(0, sizeof(KeyType));
 
-    shared_ptr<FogKV::KVStoreBase> spKVStore;
+    shared_ptr<DaqDB::KVStoreBase> spKVStore;
     try {
         spKVStore =
-            shared_ptr<FogKV::KVStoreBase>(FogKV::KVStoreBase::Open(options));
-    } catch (FogKV::OperationFailedException &e) {
+            shared_ptr<DaqDB::KVStoreBase>(DaqDB::KVStoreBase::Open(options));
+    } catch (DaqDB::OperationFailedException &e) {
         cerr << "Failed to create KVStore: " << e.what() << endl;
         return -1;
     }
@@ -157,7 +157,7 @@ int main(int argc, const char *argv[]) {
         << flush;
 
     if (interactiveMode) {
-        FogKV::nodeCli nodeCli(spKVStore);
+        DaqDB::nodeCli nodeCli(spKVStore);
         while (nodeCli()) {
             if (!isRunning)
                 break;

--- a/examples/cli_node/nodeCli.h
+++ b/examples/cli_node/nodeCli.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <FogKV/KVStoreBase.h>
+#include <daqdb/KVStoreBase.h>
 #include <iostream>
 #include <json/json.h>
 #include <linenoise.h>
@@ -25,7 +25,7 @@ namespace {
 const unsigned int consoleHintColor = 35; // dark red
 };
 
-namespace FogKV {
+namespace DaqDB {
 
 /*!
  * Dragon shell interpreter.
@@ -33,7 +33,7 @@ namespace FogKV {
  */
 class nodeCli {
   public:
-    nodeCli(std::shared_ptr<FogKV::KVStoreBase> &spDragonSrv);
+    nodeCli(std::shared_ptr<DaqDB::KVStoreBase> &spDragonSrv);
     virtual ~nodeCli();
 
     /*!
@@ -54,16 +54,16 @@ class nodeCli {
     void _cmdStatus();
     void _cmdNodeStatus(const std::string &strLine);
 
-    FogKV::Key _strToKey(const std::string &key);
-    FogKV::Value _strToValue(const std::string &valStr);
-    FogKV::Value _allocValue(const FogKV::Key &key, const std::string &valStr);
+    DaqDB::Key _strToKey(const std::string &key);
+    DaqDB::Value _strToValue(const std::string &valStr);
+    DaqDB::Value _allocValue(const DaqDB::Key &key, const std::string &valStr);
 
-    FogKV::PrimaryKeyAttribute
+    DaqDB::PrimaryKeyAttribute
     _getKeyAttrs(unsigned char start, const std::vector<std::string> &cmdAttrs);
-    FogKV::PrimaryKeyAttribute
+    DaqDB::PrimaryKeyAttribute
     _getKeyAttr(unsigned char start, const std::vector<std::string> &cmdAttrs);
 
-    std::shared_ptr<FogKV::KVStoreBase> _spKVStore;
+    std::shared_ptr<DaqDB::KVStoreBase> _spKVStore;
     std::vector<std::string> _statusMsgs;
 
     Json::Value getPeersJson();

--- a/include/daqdb/Info.h
+++ b/include/daqdb/Info.h
@@ -15,19 +15,14 @@
 
 #pragma once
 
-namespace FogKV {
+#include <daqdb/Types.h>
 
-class Key {
-  public:
-    Key() : _data(nullptr), _size(0) {}
-    Key(char *data, size_t size) : _data(data), _size(size) {}
-    char *data() { return _data; }
-    inline const char *data() const { return _data; }
-    inline size_t size() const { return _size; }
+namespace DaqDB {
 
-  protected:
-    char *_data;
-    size_t _size;
+struct Info {
+public:
+
+	NodeId getNodeId() const;
 };
 
-} // namespace FogKV
+}

--- a/include/daqdb/KVPair.h
+++ b/include/daqdb/KVPair.h
@@ -15,19 +15,20 @@
 
 #pragma once
 
-namespace FogKV {
+namespace DaqDB {
 
-class Value {
+class KVPair {
   public:
-    Value() : _data(nullptr), _size(0) {}
-    Value(char *data, size_t size) : _data(data), _size(size) {}
-    char *data() { return _data; }
-    inline const char *data() const { return _data; }
-    inline size_t size() const { return _size; }
+    template <class T> T key() const {
+        return *reinterpret_cast<const T *>(key());
+    }
 
-  protected:
-    char *_data;
-    size_t _size;
+    Key key() const {}
+
+    Value value() const {}
+
+    size_t keySize();
+    size_t size() const;
 };
 
-} // namespace FogKV
+}

--- a/include/daqdb/KVStore.h
+++ b/include/daqdb/KVStore.h
@@ -16,13 +16,13 @@
 #pragma once
 
 #include <string>
-#include "FogKV/Status.h"
-#include "FogKV/Options.h"
-#include "FogKV/KVStoreBase.h"
+#include "daqdb/Status.h"
+#include "daqdb/Options.h"
+#include "daqdb/KVStoreBase.h"
 
 #include <boost/hana.hpp>
 
-namespace FogKV {
+namespace DaqDB {
 
 template <class T>
 bool Set(KeyDescriptor &key)
@@ -138,4 +138,4 @@ public:
 
 };
 
-} // namespace FogKV
+}

--- a/include/daqdb/KVStoreBase.h
+++ b/include/daqdb/KVStoreBase.h
@@ -21,14 +21,14 @@
 #pragma once
 
 #include <string>
-#include "FogKV/Status.h"
-#include "FogKV/Options.h"
-#include "FogKV/Key.h"
-#include "FogKV/Value.h"
-#include "FogKV/KVPair.h"
+#include "daqdb/Status.h"
+#include "daqdb/Options.h"
+#include "daqdb/Key.h"
+#include "daqdb/Value.h"
+#include "daqdb/KVPair.h"
 #include <functional>
 
-namespace FogKV {
+namespace DaqDB {
 
 /**
  * The KVStoreBase is a distributed Key-Value store.
@@ -383,4 +383,4 @@ class KVStoreBase {
     virtual void ChangeOptions(Key &key, const AllocOptions &options) = 0;
 };
 
-} // namespace FogKV
+}

--- a/include/daqdb/Key.h
+++ b/include/daqdb/Key.h
@@ -15,20 +15,19 @@
 
 #pragma once
 
-namespace FogKV {
+namespace DaqDB {
 
-class KVPair {
+class Key {
   public:
-    template <class T> T key() const {
-        return *reinterpret_cast<const T *>(key());
-    }
+    Key() : _data(nullptr), _size(0) {}
+    Key(char *data, size_t size) : _data(data), _size(size) {}
+    char *data() { return _data; }
+    inline const char *data() const { return _data; }
+    inline size_t size() const { return _size; }
 
-    Key key() const {}
-
-    Value value() const {}
-
-    size_t keySize();
-    size_t size() const;
+  protected:
+    char *_data;
+    size_t _size;
 };
 
-} // namespace FogKV
+}

--- a/include/daqdb/Options.h
+++ b/include/daqdb/Options.h
@@ -19,9 +19,9 @@
 #include <functional>
 #include <vector>
 
-#include <FogKV/Types.h>
+#include <daqdb/Types.h>
 
-namespace FogKV {
+namespace DaqDB {
 
 enum PrimaryKeyAttribute : std::int8_t {
     EMPTY       = 0,
@@ -148,4 +148,4 @@ struct Options {
     PMEMOptions PMEM;
 };
 
-} // namespace FogKV
+}

--- a/include/daqdb/Status.h
+++ b/include/daqdb/Status.h
@@ -19,7 +19,7 @@
 #include <limits>
 #include <string>
 
-namespace FogKV {
+namespace DaqDB {
 
 enum StatusCode : long {
     Ok = 0,
@@ -63,4 +63,4 @@ struct Status {
 
 Status errno2status(int err);
 
-} // namespace FogKV
+}

--- a/include/daqdb/Types.h
+++ b/include/daqdb/Types.h
@@ -17,7 +17,7 @@
 
 #include <stdexcept>
 
-namespace FogKV {
+namespace DaqDB {
 
 typedef unsigned int NodeId;
 
@@ -66,4 +66,4 @@ class QueueFullException : public std::runtime_error {
     QueueFullException() : runtime_error("Queue full") {}
 };
 
-} // namespace FogKV
+}

--- a/include/daqdb/Value.h
+++ b/include/daqdb/Value.h
@@ -15,14 +15,19 @@
 
 #pragma once
 
-#include <FogKV/Types.h>
+namespace DaqDB {
 
-namespace FogKV {
+class Value {
+  public:
+    Value() : _data(nullptr), _size(0) {}
+    Value(char *data, size_t size) : _data(data), _size(size) {}
+    char *data() { return _data; }
+    inline const char *data() const { return _data; }
+    inline size_t size() const { return _size; }
 
-struct Info {
-public:
-
-	NodeId getNodeId() const;
+  protected:
+    char *_data;
+    size_t _size;
 };
 
-} // namespace FogKV
+}

--- a/include/dht/CChordNode.h
+++ b/include/dht/CChordNode.h
@@ -18,13 +18,13 @@
 #include <asio/io_service.hpp>
 #include <dht/DhtNode.h>
 
-namespace FogKV
+namespace DaqDB
 {
 
 /*!
  * Adapter for cChord classes.
  */
-class CChordAdapter : public FogKV::DhtNode {
+class CChordAdapter : public DaqDB::DhtNode {
 public:
 	CChordAdapter(asio::io_service &io_service, unsigned short port,
 		      unsigned short dragonPort, int id);

--- a/include/dht/DhtNode.h
+++ b/include/dht/DhtNode.h
@@ -18,7 +18,7 @@
 #include <asio/io_service.hpp>
 #include <dht/PureNode.h>
 
-namespace FogKV
+namespace DaqDB
 {
 
 /*!

--- a/include/dht/PureNode.h
+++ b/include/dht/PureNode.h
@@ -17,7 +17,7 @@
 
 #include <iostream>
 
-namespace FogKV
+namespace DaqDB
 {
 
 /*!

--- a/lib/debug/Logger.cpp
+++ b/lib/debug/Logger.cpp
@@ -15,9 +15,9 @@
 
 #include "Logger.h"
 
-namespace FogKV {
+namespace DaqDB {
 
-FogKV::Logger gLog;
+DaqDB::Logger gLog;
 
 Logger::Logger() {}
 

--- a/lib/debug/Logger.h
+++ b/lib/debug/Logger.h
@@ -23,7 +23,7 @@
 
 #include <functional>
 
-namespace FogKV {
+namespace DaqDB {
 
 class Logger {
   public:
@@ -37,6 +37,6 @@ private:
     std::function<void(std::string)> _logFunc = nullptr;
 };
 
-extern FogKV::Logger gLog;
+extern DaqDB::Logger gLog;
 
 } /* namespace FogKV */

--- a/lib/dht/CChordNode.cpp
+++ b/lib/dht/CChordNode.cpp
@@ -29,7 +29,7 @@ const string dhtOverlayIdentifier = "chordTestBed";
 const string rootDirectory = ".";
 };
 
-namespace FogKV
+namespace DaqDB
 {
 
 CChordAdapter::CChordAdapter(asio::io_service &io_service, unsigned short port,
@@ -41,8 +41,8 @@ CChordAdapter::CChordAdapter(asio::io_service &io_service, unsigned short port,
 CChordAdapter::CChordAdapter(asio::io_service &io_service, unsigned short port,
                              unsigned short dragonPort, int id,
                              bool skipShutDown)
-    : FogKV::DhtNode(io_service, port, dragonPort), skipShutDown(skipShutDown) {
-    auto dhtPort = FogKV::utils::getFreePort(io_service, port, true);
+    : DaqDB::DhtNode(io_service, port, dragonPort), skipShutDown(skipShutDown) {
+    auto dhtPort = DaqDB::utils::getFreePort(io_service, port, true);
 
     string backBone[] = {
         dhtBackBoneIp,

--- a/lib/dht/DhtNode.cpp
+++ b/lib/dht/DhtNode.cpp
@@ -15,7 +15,7 @@
 
 #include <dht/DhtNode.h>
 
-namespace FogKV
+namespace DaqDB
 {
 
 DhtNode::DhtNode(asio::io_service& io_service, unsigned short port, unsigned short dragonPort)

--- a/lib/dht/DhtUtils.cpp
+++ b/lib/dht/DhtUtils.cpp
@@ -21,7 +21,7 @@
 #include <asio/ip/tcp.hpp>
 #include <asio/signal_set.hpp>
 
-namespace FogKV
+namespace DaqDB
 {
 namespace utils
 {

--- a/lib/dht/DhtUtils.h
+++ b/lib/dht/DhtUtils.h
@@ -17,7 +17,7 @@
 
 #include <asio/io_service.hpp>
 
-namespace FogKV
+namespace DaqDB
 {
 namespace utils
 {

--- a/lib/dht/PureNode.cpp
+++ b/lib/dht/PureNode.cpp
@@ -15,7 +15,7 @@
 
 #include <dht/PureNode.h>
 
-namespace FogKV
+namespace DaqDB
 {
 
 PureNode::PureNode() : _port(0), _dhtId(0), _dragonPort(0)

--- a/lib/store/KVStoreBaseImpl.h
+++ b/lib/store/KVStoreBaseImpl.h
@@ -19,12 +19,12 @@
 #include "OffloadRqstPooler.h"
 #include "RTreeEngine.h"
 #include "RqstPooler.h"
-#include <FogKV/KVStoreBase.h>
+#include <daqdb/KVStoreBase.h>
 #include <dht/CChordNode.h>
 #include <dht/DhtNode.h>
 #include <mutex>
 
-namespace FogKV {
+namespace DaqDB {
 
 class KVStoreBaseImpl : public KVStoreBase {
   public:
@@ -84,8 +84,8 @@ class KVStoreBaseImpl : public KVStoreBase {
 
     size_t mKeySize;
     Options mOptions;
-    std::unique_ptr<FogKV::DhtNode> mDhtNode;
-    std::shared_ptr<FogKV::RTreeEngine> mRTree;
+    std::unique_ptr<DaqDB::DhtNode> mDhtNode;
+    std::shared_ptr<DaqDB::RTreeEngine> mRTree;
     std::mutex mLock;
 
     std::vector<RqstPooler *> _rqstPoolers;
@@ -95,4 +95,4 @@ class KVStoreBaseImpl : public KVStoreBase {
     bool _offloadEnabled = false;
 };
 
-} // namespace FogKV
+}

--- a/lib/store/OffloadFreeList.cpp
+++ b/lib/store/OffloadFreeList.cpp
@@ -18,7 +18,7 @@
 #include "../debug/Logger.h"
 #include "OffloadFreeList.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 OffloadFreeList::OffloadFreeList() {}
 

--- a/lib/store/OffloadFreeList.h
+++ b/lib/store/OffloadFreeList.h
@@ -21,7 +21,7 @@
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/transaction.hpp>
 
-namespace FogKV {
+namespace DaqDB {
 
 using pmem::obj::p;
 using pmem::obj::persistent_ptr;

--- a/lib/store/OffloadReactor.cpp
+++ b/lib/store/OffloadReactor.cpp
@@ -25,7 +25,7 @@
 
 #define OFFLOAD_POOLER_INTERVAL_MICR_SEC 100
 
-namespace FogKV {
+namespace DaqDB {
 
 void reactor_start_clb(void *offload_reactor, void *arg2) {
     OffloadReactor *offloadReactor =

--- a/lib/store/OffloadReactor.h
+++ b/lib/store/OffloadReactor.h
@@ -29,7 +29,7 @@
 
 #include "OffloadRqstPooler.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 using OffloadReactorShutdownCallback = std::function<void()>;
 

--- a/lib/store/OffloadRqstPooler.cpp
+++ b/lib/store/OffloadRqstPooler.cpp
@@ -14,7 +14,7 @@
  */
 
 #include "OffloadRqstPooler.h"
-#include "FogKV/Status.h"
+#include "daqdb/Status.h"
 #include "RTree.h"
 
 #include <boost/asio.hpp>
@@ -33,7 +33,7 @@
 #define LAYOUT "queue"
 #define CREATE_MODE_RW (S_IWUSR | S_IRUSR)
 
-namespace FogKV {
+namespace DaqDB {
 
 /*
  * Callback function for write io completion.
@@ -87,7 +87,7 @@ OffloadRqstMsg::OffloadRqstMsg(const OffloadRqstOperation op, const char *key,
     : op(op), key(key), keySize(keySize), value(value), valueSize(valueSize),
       clb(clb) {}
 
-OffloadRqstPooler::OffloadRqstPooler(std::shared_ptr<FogKV::RTreeEngine> rtree,
+OffloadRqstPooler::OffloadRqstPooler(std::shared_ptr<DaqDB::RTreeEngine> rtree,
                                      BdevContext &bdevContext,
                                      uint64_t offloadBlockSize)
     : rtree(rtree), _bdevContext(bdevContext) {

--- a/lib/store/OffloadRqstPooler.h
+++ b/lib/store/OffloadRqstPooler.h
@@ -25,12 +25,12 @@
 #include "spdk/queue.h"
 
 #include "RTreeEngine.h"
-#include <FogKV/KVStoreBase.h>
+#include <daqdb/KVStoreBase.h>
 #include "OffloadFreeList.h"
 
 #define OFFLOAD_DEQUEUE_RING_LIMIT 1024
 
-namespace FogKV {
+namespace DaqDB {
 
 enum class OffloadRqstOperation : std::int8_t {
     NONE = 0,
@@ -74,7 +74,7 @@ struct IoContext {
     uint64_t *lba = nullptr;
     bool updatePmemIOV = false;
 
-    std::shared_ptr<FogKV::RTreeEngine> rtree;
+    std::shared_ptr<DaqDB::RTreeEngine> rtree;
     KVStoreBase::KVStoreBaseCallback clb;
 };
 
@@ -90,7 +90,7 @@ class OffloadRqstPoolerInterface {
 
 class OffloadRqstPooler : public OffloadRqstPoolerInterface {
   public:
-    OffloadRqstPooler(std::shared_ptr<FogKV::RTreeEngine> rtree,
+    OffloadRqstPooler(std::shared_ptr<DaqDB::RTreeEngine> rtree,
                       BdevContext &bdevContext, uint64_t offloadBlockSize);
     virtual ~OffloadRqstPooler();
 
@@ -110,14 +110,14 @@ class OffloadRqstPooler : public OffloadRqstPoolerInterface {
     unsigned short processArrayCount = 0;
     OffloadRqstMsg *processArray[OFFLOAD_DEQUEUE_RING_LIMIT];
 
-    std::shared_ptr<FogKV::RTreeEngine> rtree;
+    std::shared_ptr<DaqDB::RTreeEngine> rtree;
 
     OffloadFreeList *freeLbaList = nullptr;
 
   private:
     uint64_t _blkForLba = 0;
     struct BdevContext _bdevContext;
-    pool<FogKV::OffloadFreeList> _poolFreeList;
+    pool<DaqDB::OffloadFreeList> _poolFreeList;
 };
 
 } /* namespace FogKV */

--- a/lib/store/RTree.cpp
+++ b/lib/store/RTree.cpp
@@ -16,7 +16,7 @@
 #include "RTree.h"
 #include <iostream>
 
-namespace FogKV {
+namespace DaqDB {
 #define LAYOUT "rtree"
 
 RTree::RTree(const string &_path, const size_t size) {
@@ -242,4 +242,4 @@ ValueWrapper *Tree::findValueInNode(persistent_ptr<Node> current,
 
     return val;
 }
-} // namespace FogKV
+}

--- a/lib/store/RTree.h
+++ b/lib/store/RTree.h
@@ -43,7 +43,7 @@ using namespace pmem::obj;
 
 enum OBJECT_TYPES { VALUE, IOV };
 
-namespace FogKV {
+namespace DaqDB {
 
 struct locationStruct {
     locationStruct() : value(EMPTY) {}
@@ -95,7 +95,7 @@ class Tree {
   private:
 };
 
-class RTree : public FogKV::RTreeEngine {
+class RTree : public DaqDB::RTreeEngine {
   public:
     RTree(const string &path, const size_t size);
     virtual ~RTree();
@@ -119,5 +119,5 @@ class RTree : public FogKV::RTreeEngine {
   private:
     Tree *tree;
 };
-} // namespace FogKV
+}
 #endif /* LIB_STORE_RTREE_H_ */

--- a/lib/store/RTreeEngine.cpp
+++ b/lib/store/RTreeEngine.cpp
@@ -15,11 +15,11 @@
 
 #include "RTreeEngine.h"
 #include "RTree.h"
-namespace FogKV {
+namespace DaqDB {
 RTreeEngine *RTreeEngine::Open(const string &engine, // open storage engine
                                const string &path,   // path to persistent pool
                                size_t size) {
-    return new FogKV::RTree(path, size);
+    return new DaqDB::RTree(path, size);
 }
 
 void RTreeEngine::Close(RTreeEngine *kv) {} // close storage engine

--- a/lib/store/RTreeEngine.h
+++ b/lib/store/RTreeEngine.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "FogKV/Status.h"
+#include "daqdb/Status.h"
 
 #include <libpmemobj++/make_persistent.hpp>
 #include <libpmemobj++/make_persistent_array.hpp>
@@ -29,7 +29,7 @@ using std::to_string;
 
 enum LOCATIONS { EMPTY, PMEM, DISK };
 
-namespace FogKV {
+namespace DaqDB {
 
 class RTreeEngine {
   public:
@@ -56,4 +56,4 @@ class RTreeEngine {
     virtual StatusCode UpdateValueWrapper(const char *key, uint64_t *ptr,
                                           size_t size) = 0;
 };
-} // namespace FogKV
+}

--- a/lib/store/RqstPooler.cpp
+++ b/lib/store/RqstPooler.cpp
@@ -23,7 +23,7 @@
 #include "../debug/Logger.h"
 #include "spdk/env.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 RqstMsg::RqstMsg(const RqstOperation op, const char *key, const size_t keySize,
                  const char *value, size_t valueSize,
@@ -31,7 +31,7 @@ RqstMsg::RqstMsg(const RqstOperation op, const char *key, const size_t keySize,
     : op(op), key(key), keySize(keySize), value(value), valueSize(valueSize),
       clb(clb) {}
 
-RqstPooler::RqstPooler(std::shared_ptr<FogKV::RTreeEngine> rtree,
+RqstPooler::RqstPooler(std::shared_ptr<DaqDB::RTreeEngine> rtree,
                        const size_t cpuCore)
     : isRunning(0), _thread(nullptr), rtree(rtree), _cpuCore(cpuCore) {
 

--- a/lib/store/RqstPooler.h
+++ b/lib/store/RqstPooler.h
@@ -25,11 +25,11 @@
 #include "spdk/io_channel.h"
 #include "spdk/queue.h"
 
-#include <FogKV/KVStoreBase.h>
+#include <daqdb/KVStoreBase.h>
 
 #define DEQUEUE_RING_LIMIT 1024
 
-namespace FogKV {
+namespace DaqDB {
 
 enum class RqstOperation : std::int8_t { NONE = 0, GET = 1, PUT = 2, UPDATE = 3 };
 
@@ -59,7 +59,7 @@ class RqstPoolerInterface {
 
 class RqstPooler : public RqstPoolerInterface {
   public:
-    RqstPooler(std::shared_ptr<FogKV::RTreeEngine> rtree,
+    RqstPooler(std::shared_ptr<DaqDB::RTreeEngine> rtree,
                const size_t cpuCore = 0);
     virtual ~RqstPooler();
 
@@ -71,7 +71,7 @@ class RqstPooler : public RqstPoolerInterface {
     OffloadRqstPooler *offloadPooler = nullptr;
 
     std::atomic<int> isRunning;
-    std::shared_ptr<FogKV::RTreeEngine> rtree;
+    std::shared_ptr<DaqDB::RTreeEngine> rtree;
     struct spdk_ring *rqstRing;
 
     unsigned short processArrayCount = 0;

--- a/path-finding/poc_0_cpu_usage/bench_node/CpuMeter.cpp
+++ b/path-finding/poc_0_cpu_usage/bench_node/CpuMeter.cpp
@@ -40,7 +40,7 @@
 #include "CpuMeter.h"
 #include "debug.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 CpuMeter::CpuMeter(bool enableCSV) :
 		_csvEnabled(enableCSV) {
@@ -121,7 +121,7 @@ std::string CpuMeter::format() {
 	return _timer.format();
 }
 
-void CpuMeter::logCpuUsage(FogKV::SimFogKV* simFog) {
+void CpuMeter::logCpuUsage(DaqDB::SimFogKV* simFog) {
 
 	boost::posix_time::ptime now =
 			boost::posix_time::second_clock::local_time();

--- a/path-finding/poc_0_cpu_usage/bench_node/CpuMeter.h
+++ b/path-finding/poc_0_cpu_usage/bench_node/CpuMeter.h
@@ -45,7 +45,7 @@
 
 using namespace boost::timer;
 
-namespace FogKV
+namespace DaqDB
 {
 
 class CpuMeter {
@@ -60,7 +60,7 @@ public:
 
 	std::string format();
 
-	void logCpuUsage(FogKV::SimFogKV* simFog);
+	void logCpuUsage(DaqDB::SimFogKV* simFog);
 
 private:
 	bool _csvEnabled;

--- a/path-finding/poc_0_cpu_usage/bench_node/IoMeter.cpp
+++ b/path-finding/poc_0_cpu_usage/bench_node/IoMeter.cpp
@@ -31,7 +31,7 @@
  */
 #include "IoMeter.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 IoMeter::IoMeter() {
 	_snapshot_time = boost::posix_time::second_clock::local_time();

--- a/path-finding/poc_0_cpu_usage/bench_node/IoMeter.h
+++ b/path-finding/poc_0_cpu_usage/bench_node/IoMeter.h
@@ -35,7 +35,7 @@
 #include <tuple>
 #include "boost/date_time/posix_time/posix_time.hpp"
 
-namespace FogKV {
+namespace DaqDB {
 
 class IoMeter {
 public:

--- a/path-finding/poc_0_cpu_usage/bench_node/SimFogKV.cpp
+++ b/path-finding/poc_0_cpu_usage/bench_node/SimFogKV.cpp
@@ -50,7 +50,7 @@ using namespace log4cxx::xml;
 using namespace log4cxx::helpers;
 #endif
 
-namespace FogKV {
+namespace DaqDB {
 
 SimFogKV::SimFogKV(const std::string &diskPath, const unsigned int elementSize,
 		const unsigned int limitGet, const unsigned int limitPut) :

--- a/path-finding/poc_0_cpu_usage/bench_node/SimFogKV.h
+++ b/path-finding/poc_0_cpu_usage/bench_node/SimFogKV.h
@@ -36,7 +36,7 @@
 #include "workers/AepWorker.h"
 #include "workers/DiskWorker.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 class SimFogKV {
 public:
@@ -53,8 +53,8 @@ public:
 	void TestSimpleGetPut(const unsigned int numOfGetOperations, const unsigned int numOfPutOperations);
 
 private:
-	FogKV::AepWorker _aepWorker;
-	FogKV::DiskWorker _diskWorker;
+	DaqDB::AepWorker _aepWorker;
+	DaqDB::DiskWorker _diskWorker;
 	unsigned int _limit_get;
 	unsigned int _limit_put;
 };

--- a/path-finding/poc_0_cpu_usage/bench_node/benchmark.cpp
+++ b/path-finding/poc_0_cpu_usage/bench_node/benchmark.cpp
@@ -61,7 +61,7 @@ LoggerPtr benchDragon(Logger::getLogger("benchmark"));
 /*!
  *
  */
-void logCpuUsage(asio::deadline_timer* cpuLogTimer, FogKV::CpuMeter* cpuMeter, FogKV::SimFogKV* simFog, Node* node) {
+void logCpuUsage(asio::deadline_timer* cpuLogTimer, DaqDB::CpuMeter* cpuMeter, DaqDB::SimFogKV* simFog, Node* node) {
 
 	double txU = node->getAvgTxBuffUsage(true) * 100.0;
 	double rxU = node->getAvgRxBuffUsage(true) * 100.0;
@@ -187,8 +187,8 @@ int main(int argc, const char *argv[]) {
 	asio::signal_set signals(io_service, SIGINT, SIGTERM);
 	signals.async_wait(bind(&asio::io_service::stop, &io_service));
 
-	FogKV::CpuMeter cpuMeter(enableCSV);
-	FogKV::SimFogKV simFog(diskPath, diskBuffSize);
+	DaqDB::CpuMeter cpuMeter(enableCSV);
+	DaqDB::SimFogKV simFog(diskPath, diskBuffSize);
 
 	asio::deadline_timer cpuLogTimer(io_service,
 			boost::posix_time::seconds(1));

--- a/path-finding/poc_0_cpu_usage/bench_node/workers/AepWorker.cpp
+++ b/path-finding/poc_0_cpu_usage/bench_node/workers/AepWorker.cpp
@@ -48,7 +48,7 @@ using namespace log4cxx::xml;
 using namespace log4cxx::helpers;
 #endif
 
-namespace FogKV {
+namespace DaqDB {
 
 AepWorker::AepWorker() {
 	auto isTemporaryDb = true;
@@ -57,7 +57,7 @@ AepWorker::AepWorker() {
 	LOG4CXX_INFO(log4cxx::Logger::getRootLogger(), "New PmemKVStore created");
 #endif
 	this->_spStore.reset(
-		new FogKV::PmemKVStore(1, isTemporaryDb));
+		new DaqDB::PmemKVStore(1, isTemporaryDb));
 }
 
 AepWorker::~AepWorker() {

--- a/path-finding/poc_0_cpu_usage/bench_node/workers/AepWorker.h
+++ b/path-finding/poc_0_cpu_usage/bench_node/workers/AepWorker.h
@@ -37,7 +37,7 @@
 #include "../../../lib/store/KVStore.h"
 #include "../IoMeter.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 class AepWorker {
 public:
@@ -53,7 +53,7 @@ public:
 
 private:
 	IoMeter _ioMeter;
-	std::unique_ptr<FogKV::KVStore> _spStore;
+	std::unique_ptr<DaqDB::KVStore> _spStore;
 
 };
 

--- a/path-finding/poc_0_cpu_usage/bench_node/workers/DiskWorker.cpp
+++ b/path-finding/poc_0_cpu_usage/bench_node/workers/DiskWorker.cpp
@@ -29,7 +29,7 @@ using namespace log4cxx::xml;
 using namespace log4cxx::helpers;
 #endif
 
-namespace FogKV {
+namespace DaqDB {
 
 DiskWorker::DiskWorker(const std::string &diskPath,
 		const unsigned int elementSize) :

--- a/path-finding/poc_0_cpu_usage/bench_node/workers/DiskWorker.h
+++ b/path-finding/poc_0_cpu_usage/bench_node/workers/DiskWorker.h
@@ -37,7 +37,7 @@
 #include <store/KVInterface.h>
 #include "../IoMeter.h"
 
-namespace FogKV {
+namespace DaqDB {
 
 class DiskWorker {
 public:

--- a/tests/dht/DhtUtilsTest.cpp
+++ b/tests/dht/DhtUtilsTest.cpp
@@ -67,7 +67,7 @@ unsigned short getFreePortNumber(asio::io_service &io_service) {
 BOOST_AUTO_TEST_CASE(GenRandomPort) {
 	asio::io_service io_service;
 
-	auto resultPort = FogKV::utils::getFreePort(io_service, 0);
+	auto resultPort = DaqDB::utils::getFreePort(io_service, 0);
 
 	BOOST_CHECK_GT(resultPort, reservedPortsEnd);
 	auto isFreeResult = isPortFree(io_service, resultPort);
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(GenRandomPort_DefaultIsUsed) {
 
 	auto portThatIsOpened = sshProtocolPort;
 
-	auto resultPort = FogKV::utils::getFreePort(io_service, portThatIsOpened, false);
+	auto resultPort = DaqDB::utils::getFreePort(io_service, portThatIsOpened, false);
 
 	BOOST_CHECK_GT(resultPort, reservedPortsEnd);
 	auto isFreeResult = isPortFree(io_service, resultPort);
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(GenRandomPort_DefaultNotUsed) {
 	asio::io_service io_service;
 
 	auto freePort = getRandomPortNumber();
-	auto resultPort = FogKV::utils::getFreePort(io_service, freePort, true);
+	auto resultPort = DaqDB::utils::getFreePort(io_service, freePort, true);
 
 	BOOST_CHECK_GT(resultPort, reservedPortsEnd);
 	auto isFreeResult = isPortFree(io_service, resultPort);

--- a/tests/store/OffloadFreeListTest.cpp
+++ b/tests/store/OffloadFreeListTest.cpp
@@ -37,7 +37,7 @@ using namespace fakeit;
 
 #define FREELIST_MAX_LBA 512
 
-pool<FogKV::OffloadFreeList> *g_poolFreeList = nullptr;
+pool<DaqDB::OffloadFreeList> *g_poolFreeList = nullptr;
 
 bool txAbortPred(const pmem::manual_tx_abort &ex) { return true; }
 
@@ -45,7 +45,7 @@ struct OffloadFreeListGlobalFixture {
     OffloadFreeListGlobalFixture() {
         if (boost::filesystem::exists(TEST_POOL_FREELIST_FILENAME))
             boost::filesystem::remove(TEST_POOL_FREELIST_FILENAME);
-        poolFreeList = pool<FogKV::OffloadFreeList>::create(
+        poolFreeList = pool<DaqDB::OffloadFreeList>::create(
             TEST_POOL_FREELIST_FILENAME, LAYOUT, TEST_POOL_FREELIST_SIZE,
             CREATE_MODE_RW);
         g_poolFreeList = &poolFreeList;
@@ -54,7 +54,7 @@ struct OffloadFreeListGlobalFixture {
         if (boost::filesystem::exists(TEST_POOL_FREELIST_FILENAME))
             boost::filesystem::remove(TEST_POOL_FREELIST_FILENAME);
     }
-    pool<FogKV::OffloadFreeList> poolFreeList;
+    pool<DaqDB::OffloadFreeList> poolFreeList;
 };
 
 BOOST_GLOBAL_FIXTURE(OffloadFreeListGlobalFixture);
@@ -68,7 +68,7 @@ struct OffloadFreeListTestFixture {
             freeLbaList->Clear(*g_poolFreeList);
         freeLbaList->maxLba = 0;
     }
-    FogKV::OffloadFreeList *freeLbaList = nullptr;
+    DaqDB::OffloadFreeList *freeLbaList = nullptr;
 };
 
 BOOST_FIXTURE_TEST_CASE(GetLbaInit, OffloadFreeListTestFixture) {

--- a/tests/store/RqstPoolerTest.cpp
+++ b/tests/store/RqstPoolerTest.cpp
@@ -35,41 +35,41 @@ static const size_t expectedValSize = 6;
 #define BOOST_TEST_DETECT_MEMORY_LEAK 1
 
 BOOST_AUTO_TEST_CASE(ProcessEmptyRing) {
-    Mock<FogKV::RqstPooler> poolerMock;
-    Mock<FogKV::RTree> rtreeMock;
+    Mock<DaqDB::RqstPooler> poolerMock;
+    Mock<DaqDB::RTree> rtreeMock;
 
     When(OverloadedMethod(
              rtreeMock, Put,
-             FogKV::StatusCode(const char *, int32_t, const char *, int32_t)))
-        .Return(FogKV::StatusCode::Ok);
+             DaqDB::StatusCode(const char *, int32_t, const char *, int32_t)))
+        .Return(DaqDB::StatusCode::Ok);
 
-    FogKV::RqstPooler &pooler = poolerMock.get();
-    FogKV::RTreeEngine &rtree = rtreeMock.get();
+    DaqDB::RqstPooler &pooler = poolerMock.get();
+    DaqDB::RTreeEngine &rtree = rtreeMock.get();
     pooler.rtree.reset(&rtree);
 
     pooler.ProcessMsg();
     VerifyNoOtherInvocations(OverloadedMethod(
         rtreeMock, Put,
-        FogKV::StatusCode(const char *, int32_t, const char *, int32_t)));
+        DaqDB::StatusCode(const char *, int32_t, const char *, int32_t)));
 }
 
 BOOST_AUTO_TEST_CASE(ProcessPutRqst) {
 
-    Mock<FogKV::RqstPooler> poolerMock;
-    Mock<FogKV::RTree> rtreeMock;
+    Mock<DaqDB::RqstPooler> poolerMock;
+    Mock<DaqDB::RTree> rtreeMock;
 
     When(OverloadedMethod(
              rtreeMock, Put,
-             FogKV::StatusCode(const char *, int32_t, const char *, int32_t))
+             DaqDB::StatusCode(const char *, int32_t, const char *, int32_t))
              .Using(expectedKey, expectedKeySize, expectedVal, expectedValSize))
-        .Return(FogKV::StatusCode::Ok);
+        .Return(DaqDB::StatusCode::Ok);
 
-    FogKV::RqstPooler &pooler = poolerMock.get();
-    FogKV::RTreeEngine &rtree = rtreeMock.get();
+    DaqDB::RqstPooler &pooler = poolerMock.get();
+    DaqDB::RTreeEngine &rtree = rtreeMock.get();
     pooler.rtree.reset(&rtree);
 
-    pooler.processArray[0] = new FogKV::RqstMsg(
-        FogKV::RqstOperation::PUT, expectedKey, expectedKeySize, expectedVal,
+    pooler.processArray[0] = new DaqDB::RqstMsg(
+        DaqDB::RqstOperation::PUT, expectedKey, expectedKeySize, expectedVal,
         expectedValSize, nullptr);
     pooler.processArrayCount = 1;
 
@@ -77,28 +77,28 @@ BOOST_AUTO_TEST_CASE(ProcessPutRqst) {
 
     Verify(OverloadedMethod(
                rtreeMock, Put,
-               FogKV::StatusCode(const char *, int32_t, const char *, int32_t)))
+               DaqDB::StatusCode(const char *, int32_t, const char *, int32_t)))
         .Exactly(1);
 }
 
 BOOST_AUTO_TEST_CASE(ProcessMultiplePutRqst) {
 
-    Mock<FogKV::RqstPooler> poolerMock;
-    Mock<FogKV::RTree> rtreeMock;
+    Mock<DaqDB::RqstPooler> poolerMock;
+    Mock<DaqDB::RTree> rtreeMock;
 
     When(OverloadedMethod(
              rtreeMock, Put,
-             FogKV::StatusCode(const char *, int32_t, const char *, int32_t))
+             DaqDB::StatusCode(const char *, int32_t, const char *, int32_t))
              .Using(expectedKey, expectedKeySize, expectedVal, expectedValSize))
-        .AlwaysReturn(FogKV::StatusCode::Ok);
+        .AlwaysReturn(DaqDB::StatusCode::Ok);
 
-    FogKV::RqstPooler &pooler = poolerMock.get();
-    FogKV::RTreeEngine &rtree = rtreeMock.get();
+    DaqDB::RqstPooler &pooler = poolerMock.get();
+    DaqDB::RTreeEngine &rtree = rtreeMock.get();
     pooler.rtree.reset(&rtree);
 
     for (int index = 0; index < DEQUEUE_RING_LIMIT; index++) {
-        pooler.processArray[index] = new FogKV::RqstMsg(
-            FogKV::RqstOperation::PUT, expectedKey, expectedKeySize,
+        pooler.processArray[index] = new DaqDB::RqstMsg(
+            DaqDB::RqstOperation::PUT, expectedKey, expectedKeySize,
             expectedVal, expectedValSize, nullptr);
     }
     pooler.processArrayCount = DEQUEUE_RING_LIMIT;
@@ -107,70 +107,70 @@ BOOST_AUTO_TEST_CASE(ProcessMultiplePutRqst) {
 
     Verify(OverloadedMethod(
                rtreeMock, Put,
-               FogKV::StatusCode(const char *, int32_t, const char *, int32_t)))
+               DaqDB::StatusCode(const char *, int32_t, const char *, int32_t)))
         .Exactly(DEQUEUE_RING_LIMIT);
 }
 
 BOOST_AUTO_TEST_CASE(ProcessGetRqst) {
 
-    Mock<FogKV::RqstPooler> poolerMock;
-    Mock<FogKV::RTree> rtreeMock;
+    Mock<DaqDB::RqstPooler> poolerMock;
+    Mock<DaqDB::RTree> rtreeMock;
     char valRef[] = "abc";
     size_t sizeRef = 3;
 
     When(OverloadedMethod(rtreeMock, Get,
-                          FogKV::StatusCode(const char *, int32_t, void **,
+                          DaqDB::StatusCode(const char *, int32_t, void **,
                                             size_t *, uint8_t *))
              .Using(expectedKey, expectedKeySize, _, _, _))
         .AlwaysDo([&](const char *key, int32_t keySize, void **val,
                       size_t *valSize, uint8_t *) {
             *val = valRef;
             *valSize = sizeRef;
-            return FogKV::StatusCode::Ok;
+            return DaqDB::StatusCode::Ok;
         });
 
-    FogKV::RqstPooler &pooler = poolerMock.get();
-    FogKV::RTreeEngine &rtree = rtreeMock.get();
+    DaqDB::RqstPooler &pooler = poolerMock.get();
+    DaqDB::RTreeEngine &rtree = rtreeMock.get();
     pooler.rtree.reset(&rtree);
 
     pooler.processArray[0] =
-        new FogKV::RqstMsg(FogKV::RqstOperation::GET, expectedKey,
+        new DaqDB::RqstMsg(DaqDB::RqstOperation::GET, expectedKey,
                            expectedKeySize, nullptr, 0, nullptr);
     pooler.processArrayCount = 1;
 
     pooler.ProcessMsg();
 
     Verify(OverloadedMethod(rtreeMock, Get,
-                            FogKV::StatusCode(const char *, int32_t, void **,
+                            DaqDB::StatusCode(const char *, int32_t, void **,
                                               size_t *, uint8_t *)))
         .Exactly(1);
 }
 
 BOOST_AUTO_TEST_CASE(ProcessMultipleGetRqst) {
 
-    Mock<FogKV::RqstPooler> poolerMock;
-    Mock<FogKV::RTree> rtreeMock;
+    Mock<DaqDB::RqstPooler> poolerMock;
+    Mock<DaqDB::RTree> rtreeMock;
     char valRef[] = "abc";
     size_t sizeRef = 3;
 
     When(OverloadedMethod(rtreeMock, Get,
-                          FogKV::StatusCode(const char *, int32_t, void **,
+                          DaqDB::StatusCode(const char *, int32_t, void **,
                                             size_t *, uint8_t *))
              .Using(expectedKey, expectedKeySize, _, _, _))
         .AlwaysDo([&](const char *key, int32_t keySize, void **val,
                       size_t *valSize, uint8_t *) {
             *val = valRef;
             *valSize = sizeRef;
-            return FogKV::StatusCode::Ok;
+            return DaqDB::StatusCode::Ok;
         });
 
-    FogKV::RqstPooler &pooler = poolerMock.get();
-    FogKV::RTreeEngine &rtree = rtreeMock.get();
+    DaqDB::RqstPooler &pooler = poolerMock.get();
+    DaqDB::RTreeEngine &rtree = rtreeMock.get();
     pooler.rtree.reset(&rtree);
 
     for (int index = 0; index < DEQUEUE_RING_LIMIT; index++) {
         pooler.processArray[index] =
-            new FogKV::RqstMsg(FogKV::RqstOperation::GET, expectedKey,
+            new DaqDB::RqstMsg(DaqDB::RqstOperation::GET, expectedKey,
                                expectedKeySize, nullptr, 0, nullptr);
     }
     pooler.processArrayCount = DEQUEUE_RING_LIMIT;
@@ -178,31 +178,31 @@ BOOST_AUTO_TEST_CASE(ProcessMultipleGetRqst) {
     pooler.ProcessMsg();
 
     Verify(OverloadedMethod(rtreeMock, Get,
-                            FogKV::StatusCode(const char *, int32_t, void **,
+                            DaqDB::StatusCode(const char *, int32_t, void **,
                                               size_t *, uint8_t *)))
         .Exactly(DEQUEUE_RING_LIMIT);
 }
 
 BOOST_AUTO_TEST_CASE(ProcessPutTestCallback) {
 
-    Mock<FogKV::RqstPooler> poolerMock;
-    Mock<FogKV::RTree> rtreeMock;
+    Mock<DaqDB::RqstPooler> poolerMock;
+    Mock<DaqDB::RTree> rtreeMock;
 
     When(OverloadedMethod(
              rtreeMock, Put,
-             FogKV::StatusCode(const char *, int32_t, const char *, int32_t))
+             DaqDB::StatusCode(const char *, int32_t, const char *, int32_t))
              .Using(expectedKey, expectedKeySize, expectedVal, expectedValSize))
-        .Return(FogKV::StatusCode::Ok)
-        .Return(FogKV::StatusCode::UnknownError);
+        .Return(DaqDB::StatusCode::Ok)
+        .Return(DaqDB::StatusCode::UnknownError);
 
-    FogKV::RqstPooler &pooler = poolerMock.get();
-    FogKV::RTreeEngine &rtree = rtreeMock.get();
+    DaqDB::RqstPooler &pooler = poolerMock.get();
+    DaqDB::RTreeEngine &rtree = rtreeMock.get();
     pooler.rtree.reset(&rtree);
 
-    pooler.processArray[0] = new FogKV::RqstMsg(
-        FogKV::RqstOperation::PUT, expectedKey, expectedKeySize, expectedVal,
+    pooler.processArray[0] = new DaqDB::RqstMsg(
+        DaqDB::RqstOperation::PUT, expectedKey, expectedKeySize, expectedVal,
         expectedValSize,
-        [&](FogKV::KVStoreBase *kvs, FogKV::Status status, const char *key,
+        [&](DaqDB::KVStoreBase *kvs, DaqDB::Status status, const char *key,
             const size_t keySize, const char *value, const size_t valueSize) {
             BOOST_REQUIRE(status.ok());
             BOOST_CHECK_EQUAL(key, expectedKey);
@@ -211,10 +211,10 @@ BOOST_AUTO_TEST_CASE(ProcessPutTestCallback) {
             BOOST_CHECK_EQUAL(valueSize, expectedValSize);
         });
 
-    pooler.processArray[1] = new FogKV::RqstMsg(
-        FogKV::RqstOperation::PUT, expectedKey, expectedKeySize, expectedVal,
+    pooler.processArray[1] = new DaqDB::RqstMsg(
+        DaqDB::RqstOperation::PUT, expectedKey, expectedKeySize, expectedVal,
         expectedKeySize,
-        [&](FogKV::KVStoreBase *kvs, FogKV::Status status, const char *key,
+        [&](DaqDB::KVStoreBase *kvs, DaqDB::Status status, const char *key,
             const size_t keySize, const char *value, const size_t valueSize) {
             BOOST_REQUIRE(!status.ok());
             BOOST_CHECK_EQUAL(key, expectedKey);
@@ -228,50 +228,50 @@ BOOST_AUTO_TEST_CASE(ProcessPutTestCallback) {
 
     Verify(OverloadedMethod(
                rtreeMock, Put,
-               FogKV::StatusCode(const char *, int32_t, const char *, int32_t)))
+               DaqDB::StatusCode(const char *, int32_t, const char *, int32_t)))
         .Exactly(2);
 }
 
 BOOST_AUTO_TEST_CASE(ProcessGetTestCallback) {
 
-    Mock<FogKV::RqstPooler> poolerMock;
-    Mock<FogKV::RTree> rtreeMock;
+    Mock<DaqDB::RqstPooler> poolerMock;
+    Mock<DaqDB::RTree> rtreeMock;
     char valRef[] = "abc";
     size_t sizeRef = 3;
 
     When(OverloadedMethod(rtreeMock, Get,
-                          FogKV::StatusCode(const char *, int32_t, void **,
+                          DaqDB::StatusCode(const char *, int32_t, void **,
                                             size_t *, uint8_t *))
              .Using(expectedKey, expectedKeySize, _, _, _))
         .Do([&](const char *key, int32_t keySize, void **val, size_t *valSize,
                 uint8_t *) {
             *val = valRef;
             *valSize = sizeRef;
-            return FogKV::StatusCode::Ok;
+            return DaqDB::StatusCode::Ok;
         })
         .Do([&](const char *key, int32_t keySize, void **val, size_t *valSize,
                 uint8_t *) {
             *val = valRef;
             *valSize = sizeRef;
-            return FogKV::StatusCode::KeyNotFound;
+            return DaqDB::StatusCode::KeyNotFound;
         });
 
-    FogKV::RqstPooler &pooler = poolerMock.get();
-    FogKV::RTreeEngine &rtree = rtreeMock.get();
+    DaqDB::RqstPooler &pooler = poolerMock.get();
+    DaqDB::RTreeEngine &rtree = rtreeMock.get();
     pooler.rtree.reset(&rtree);
 
-    pooler.processArray[0] = new FogKV::RqstMsg(
-        FogKV::RqstOperation::GET, expectedKey, expectedKeySize, nullptr, 0,
-        [&](FogKV::KVStoreBase *kvs, FogKV::Status status, const char *key,
+    pooler.processArray[0] = new DaqDB::RqstMsg(
+        DaqDB::RqstOperation::GET, expectedKey, expectedKeySize, nullptr, 0,
+        [&](DaqDB::KVStoreBase *kvs, DaqDB::Status status, const char *key,
             const size_t keySize, const char *value, const size_t valueSize) {
             BOOST_REQUIRE(status.ok());
             BOOST_CHECK_EQUAL(key, expectedKey);
             BOOST_CHECK_EQUAL(keySize, expectedKeySize);
         });
 
-    pooler.processArray[1] = new FogKV::RqstMsg(
-        FogKV::RqstOperation::GET, expectedKey, expectedKeySize, nullptr, 0,
-        [&](FogKV::KVStoreBase *kvs, FogKV::Status status, const char *key,
+    pooler.processArray[1] = new DaqDB::RqstMsg(
+        DaqDB::RqstOperation::GET, expectedKey, expectedKeySize, nullptr, 0,
+        [&](DaqDB::KVStoreBase *kvs, DaqDB::Status status, const char *key,
             const size_t keySize, const char *value, const size_t valueSize) {
             BOOST_REQUIRE(!status.ok());
             BOOST_CHECK_EQUAL(key, expectedKey);
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(ProcessGetTestCallback) {
     pooler.ProcessMsg();
 
     Verify(OverloadedMethod(rtreeMock, Get,
-                            FogKV::StatusCode(const char *, int32_t, void **,
+                            DaqDB::StatusCode(const char *, int32_t, void **,
                                               size_t *, uint8_t *)))
         .Exactly(2);
 }


### PR DESCRIPTION
This patch renames main project namespace and API in "include" folder.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>