### PR TITLE
Temporarily disabling xreserve

### DIFF
--- a/apps/minidaq/MinidaqFfNode.h
+++ b/apps/minidaq/MinidaqFfNode.h
@@ -42,7 +42,7 @@ class MinidaqFfNode : public MinidaqNode {
     int _baseId = 0;
     int _nSubdetectors = 0;
     int _delay_us = 0;
-    int _maxRetries = 100;
+    int _maxRetries = 100000;
 
   private:
     double _acceptLevel = 1.0; // desired acceptance level for filtering nodes

--- a/lib/pmem/RTree.cpp
+++ b/lib/pmem/RTree.cpp
@@ -154,8 +154,13 @@ StatusCode RTree::AllocValueForKey(const char *key, size_t size, char **value) {
     ValueWrapper *val = tree->findValueInNode(tree->treeRoot->rootNode, key);
     val->actionValue = new pobj_action[1];
     pmemoid poid =
+#ifdef USE_XRESERVE
         pmemobj_xreserve(tree->_pm_pool.get_handle(), &(val->actionValue[0]),
                          size, VALUE, POBJ_CLASS_ID(tree->alloc_class));
+#else
+        pmemobj_reserve(tree->_pm_pool.get_handle(), &(val->actionValue[0]),
+                        size, VALUE);
+#endif /* USE_XRESERVE */
     if (OID_IS_NULL(poid)) {
         delete val->actionValue;
         val->actionValue = nullptr;


### PR DESCRIPTION
Xreserve seems to have problem reclaiming freed objects, so in longer
term it starts to fail and new allocations are not possible.