### PR TITLE
Remove asio headers from public API

### DIFF
--- a/examples/clinode/node.cpp
+++ b/examples/clinode/node.cpp
@@ -15,8 +15,6 @@
 
 #include <iostream>
 
-#include <asio/ip/tcp.hpp>
-#include <asio/signal_set.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/bind.hpp>
 #include <boost/format.hpp>

--- a/include/daqdb/Options.h
+++ b/include/daqdb/Options.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <asio/io_service.hpp>
 #include <functional>
 #include <vector>
 

--- a/lib/core/Env.cpp
+++ b/lib/core/Env.cpp
@@ -13,6 +13,7 @@
  * stated in the License.
  */
 
+#include <asio/io_service.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 

--- a/tests/functional/CMakeLists.txt
+++ b/tests/functional/CMakeLists.txt
@@ -3,14 +3,12 @@ cmake_minimum_required(VERSION 3.5)
 project(daqdb_func_test)
 
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_LOG_DYN_LINK")
 
 include(FindPkgConfig)
 find_package(PkgConfig)
 find_package(Boost REQUIRED COMPONENTS program_options log log_setup system filesystem thread)
 find_package(Threads REQUIRED)
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_LOG_DYN_LINK")
 
 set(ROOT_DAQDB_DIR ${PROJECT_SOURCE_DIR}/../..)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ROOT_DAQDB_DIR}/bin)

--- a/tests/functional/base_operations.h
+++ b/tests/functional/base_operations.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <asio/io_service.hpp>
+
 #include <daqdb/KVStoreBase.h>
 #include <daqdb/Key.h>
 #include <daqdb/Options.h>


### PR DESCRIPTION
This patch moves asio headers from public API to library internals.
There is issue in eRPC related to this change. eRPC redefines some of macros defined in
asio/io_service.hpp.

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>