### PR TITLE
minidaq: fixing key struct for RTree

### DIFF
--- a/apps/minidaq/MinidaqNode.h
+++ b/apps/minidaq/MinidaqNode.h
@@ -25,13 +25,13 @@
 
 namespace DaqDB {
 
-struct MinidaqKey {
+struct __attribute__ ((packed)) MinidaqKey {
     MinidaqKey() : eventId(0), subdetectorId(0), runId(0){};
     MinidaqKey(uint64_t e, uint16_t s, uint16_t r)
         : eventId(e), subdetectorId(s), runId(r) {}
+    uint64_t eventId;
     uint16_t subdetectorId;
     uint16_t runId;
-    uint64_t eventId;
 };
 
 class MinidaqNode {


### PR DESCRIPTION
For ARTree minidaq will have to change to:

{
    uint16_t runId;
    uint16_t subdetectorId;
    uint64_t eventId;
}