### PR TITLE
artree: increasing alloc block size

### DIFF
--- a/lib/pmem/ARTree.h
+++ b/lib/pmem/ARTree.h
@@ -61,7 +61,7 @@ const int PREALLOC_LEVELS = 1;
 // Allocation class alignment
 #define ALLOC_CLASS_ALIGNMENT 0
 // Units per allocation block.
-#define ALLOC_CLASS_UNITS_PER_BLOCK 1000
+#define ALLOC_CLASS_UNITS_PER_BLOCK 100000
 
 enum OBJECT_TYPES { VALUE, IOV };
 


### PR DESCRIPTION
This hides segfault in mutlithreaded minidaq when using the temporal pmdk branch.