### PR TITLE
Missing removal of key in functional_thin test

### DIFF
--- a/tests/functional_thin/tests/tests_multithreading.cpp
+++ b/tests/functional_thin/tests/tests_multithreading.cpp
@@ -43,6 +43,11 @@ bool threadTask(KVStoreBase *kvs, string key) {
         result = false;
     }
 
+    auto removeResult = remote_remove(kvs, getKey);
+    if (!removeResult) {
+        result = false;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>