### PR TITLE
fixing problem with threads calculation in satellite mode

### DIFF
--- a/apps/minidaq/minidaq.cpp
+++ b/apps/minidaq/minidaq.cpp
@@ -117,7 +117,9 @@ static std::unique_ptr<DaqDB::KVStoreBase> openKVS() {
     options.runtime.numOfPollers = nPoolers;
     nCoresUsed += nPoolers;
     options.runtime.numOfDhtThreads = nDhtThreads;
-    nCoresUsed += nDhtThreads;
+    if (!satellite){
+        nCoresUsed += nDhtThreads;
+    }
     if (nCoresUsed > nCores) {
         std::cout << "Not enough CPU cores." << endl;
         exit(1);


### PR DESCRIPTION
Number of DHT threads should not be added to number of all used cores while working in satellite mode because this cores are not physically used