### PR TITLE
Fix boost 1.70

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(daqdb)
 include(FindPkgConfig)
 include(CTest)
 
+# Fix https://github.com/boostorg/boost_install/issues/12#issuecomment-508683006
+set(Boost_NO_BOOST_CMAKE ON)
+
 find_package(PkgConfig)
 find_package(Boost REQUIRED COMPONENTS program_options system filesystem)
 include_directories(${Boost_INCLUDE_DIRS})

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ git submodule update --init --recursive
 * boost-test (1.64+)
 * cmake (3.11+)
 * gtest-devel (1.8+)
+* nasm (2.13.03+)
 
 ##### CERN's LHC
 

--- a/third-party/spdk.cmake
+++ b/third-party/spdk.cmake
@@ -7,7 +7,7 @@ ExternalProject_Add(project_spdk
 	SOURCE_DIR ${PROJECT_SOURCE_DIR}/spdk
 	PATCH_COMMAND ${ROOT_DAQDB_DIR}/scripts/patch_spdk_isal.sh
 	BUILD_IN_SOURCE ${PROJECT_SOURCE_DIR}/spdk
-	CONFIGURE_COMMAND "./configure --with-isal"
+	CONFIGURE_COMMAND "./configure" "--with-isal"
 	BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
 	INSTALL_COMMAND ${ROOT_DAQDB_DIR}/scripts/prepare_spdk_libs.sh
 )


### PR DESCRIPTION
Due to change in BoostFind behavior, a flag was introduced
to not use new cmake behavior, which fails to set Boos vars
in certain environments.

https://github.com/boostorg/boost_install/issues/12#issuecomment-508683006